### PR TITLE
Replace `upload-charm` with `upload-bundle` action

### DIFF
--- a/.github/workflows/publish_bundle.yaml
+++ b/.github/workflows/publish_bundle.yaml
@@ -16,12 +16,11 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-      # Note the use of the upload-charm action. Bundles can be treated as charms.
       - name: Upload Bundle
-        uses: canonical/charming-actions/upload-charm@main
+        uses: canonical/charming-actions/upload-bundle@main
         with:
             credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-            charm-path: ./bundle
+            bundle-path: ./bundle
             github-token: "${{ secrets.GITHUB_TOKEN }}"
             channel: "machine/edge"
             tag-prefix: "bundle"


### PR DESCRIPTION
This PR replaces usage of `upload-charm` action with `upload-bundle`.