### PR TITLE
CSS-9527 Add ability to provide custom CA for contracts server

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,13 @@ options:
   contracts.password:
     description: Password to authenticate with backend contracts service.
     type: string
+  contracts.ca:
+    description: |
+      A certificate of the CA that issued the certificate of the contracts service.
+      Use 'include-base64://' in a bundle to include a certificate. Otherwise,
+      pass a base64-encoded certificate (base64 of "-----BEGIN" to "-----END").
+    type: string
+    default: ""
   database.connection-pool-max:
     default: 10
     description: The maximum pool of connections to PostgreSQL.

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,8 @@
 """Livepatch machine operator charm."""
 
 import logging
+import subprocess  # nosec
+from base64 import b64decode
 from typing import Any, Tuple, Union
 
 import pgsql
@@ -38,6 +40,7 @@ REQUIRED_SETTINGS = {
 DATABASE_NAME = "livepatch"
 DATABASE_RELATION = "database"
 DATABASE_RELATION_LEGACY = "database-legacy"
+TRUSTED_CA_FILENAME = "/usr/local/share/ca-certificates/trusted-contracts.ca.crt"
 
 
 class OperatorMachineCharm(CharmBase):
@@ -161,6 +164,8 @@ class OperatorMachineCharm(CharmBase):
         if not self._database_migrated():
             return
 
+        self._update_trusted_ca_certs()
+
         configuration = {**self.config}
 
         # Leader specific configurations
@@ -227,6 +232,24 @@ class OperatorMachineCharm(CharmBase):
                     current_status.name,
                     current_status.message,
                 )
+
+    def _update_trusted_ca_certs(self):
+        """Update trusted CA certificates with the cert from configuration."""
+        if not self.config.get("contracts.ca"):
+            logging.debug("ca config not set")
+            return
+
+        cert = b64decode(self.config.get("contracts.ca")).decode("utf8")
+        cert_hash = hash(cert)
+        if self._state.contract_cert_hash and cert_hash == self._state.contract_cert_hash:
+            return
+
+        with open(TRUSTED_CA_FILENAME, "wt") as f:
+            f.write(cert)
+        self._state.contract_cert_hash = cert_hash
+        result = subprocess.check_output(["update-ca-certificates", "--fresh"], stderr=subprocess.STDOUT)  # nosec
+        logger.info("output update-ca-certificates: %s", result)
+        return
 
     # Legacy database
 

--- a/src/constants/snap.py
+++ b/src/constants/snap.py
@@ -4,6 +4,6 @@
 """Snap names and commands constants."""
 
 SERVER_SNAP_NAME = "canonical-livepatch-server"
-SERVER_SNAP_REVISION = 18
+SERVER_SNAP_REVISION = 35
 SCHEMA_UPGRADE_COMMAND = "schema-tool"
 SCHEMA_VERSION_CHECK = "check-schema-version"


### PR DESCRIPTION
# Description

This PR allows the Livepatch machine charm to be configured with a custom CA for the contracts server. The charm will add the CA to the filesystem and update the system CA certs.

# Testing

I've added a unit test to verify the decoding of the base64 file and deployed the charm locally and ensured the file is created correctly. I haven't tested whether the snap actually uses the custom CA but I did run `snap run --shell canonical-livepatch-server.livepatch` and verified that the snap can see the custom CA.