### PR TITLE
Add integration with `pro-airgapped-server`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,7 @@ options:
       A comma separated list of "user:password" pairs used for authentication.
     type: string
   contracts.enabled:
+    default: false
     description: Whether use of the contracts service is enabled.
     type: boolean
   contracts.url:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,6 +34,10 @@ requires:
   database:
     interface: postgresql_client
     limit: 1 # Most charms only handle a single PostgreSQL Application.
+  pro-airgapped-server:
+    interface: livepatch-pro-airgapped-server
+    limit: 1
+    optional: true
 
 provides:
   website:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 2.0.0
+ops ~= 2.14.1
 ops-lib-pgsql
 bcrypt
 # Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,6 +62,7 @@ class OperatorMachineCharm(CharmBase):
         """Init function."""
         super().__init__(*args)
         self._state = State(self.app, lambda: self.model.get_relation("livepatch"))
+        self.framework.observe(self.on.livepatch_relation_changed, self._on_livepatch_relation_changed)
 
         # Setup snapcache
         self.snap_cache = SnapCache()
@@ -123,6 +124,11 @@ class OperatorMachineCharm(CharmBase):
     ###################
     # LIFECYCLE HOOKS #
     ###################
+
+    def _on_livepatch_relation_changed(self, event) -> None:
+        """Handle peer `relation-changed` event."""
+        self._config_changed(event)
+
     def _install(self, _):
         """Install livepatch snap."""
         self.set_status_and_log(INSTALLING, WaitingStatus)

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,19 +6,32 @@
 
 """Livepatch machine operator charm."""
 
-from base64 import b64decode
 import logging
 import subprocess  # nosec
+from base64 import b64decode
 from typing import Any, Set, Tuple, Union
-from urllib.parse import urlunparse, ParseResult
+from urllib.parse import ParseResult, urlunparse
 
 import pgsql
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.operator_libs_linux.v2.snap import Snap, SnapCache, SnapError, SnapState
-from ops.charm import CharmBase, ConfigChangedEvent, RelationEvent, RelationChangedEvent, RelationDepartedEvent
+from ops.charm import (
+    CharmBase,
+    ConfigChangedEvent,
+    RelationChangedEvent,
+    RelationDepartedEvent,
+    RelationEvent,
+)
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation, RelationDataContent, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    Relation,
+    RelationDataContent,
+    WaitingStatus,
+)
 
 from constants.errors import SCHEMA_VERSION_CHECK_ERROR
 from constants.snap import SERVER_SNAP_NAME, SERVER_SNAP_REVISION

--- a/src/constants/snap.py
+++ b/src/constants/snap.py
@@ -4,6 +4,6 @@
 """Snap names and commands constants."""
 
 SERVER_SNAP_NAME = "canonical-livepatch-server"
-SERVER_SNAP_REVISION = 35
+SERVER_SNAP_REVISION = 36
 SCHEMA_UPGRADE_COMMAND = "schema-tool"
 SCHEMA_VERSION_CHECK = "check-schema-version"

--- a/src/constants/snap.py
+++ b/src/constants/snap.py
@@ -4,6 +4,6 @@
 """Snap names and commands constants."""
 
 SERVER_SNAP_NAME = "canonical-livepatch-server"
-SERVER_SNAP_REVISION = 36
+SERVER_SNAP_REVISION = 37
 SCHEMA_UPGRADE_COMMAND = "schema-tool"
 SCHEMA_VERSION_CHECK = "check-schema-version"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -17,6 +17,7 @@ APP_NAME = METADATA["name"]
 POSTGRES_NAME = "postgresql"
 HAPROXY_NAME = "haproxy"
 NGINX_NAME = "nginx-ingress-integrator"
+PRO_AIRGAPPED_SERVER_NAME = "pro-airgapped-server"
 
 
 async def scale(ops_test: OpsTest, application_name: str, count: int) -> None:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,8 +4,8 @@
 
 """Charm integration tests."""
 
-import logging
 import json
+import logging
 from urllib.parse import urljoin
 
 import pytest

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,6 +5,7 @@
 """Charm integration tests."""
 
 import logging
+import json
 from urllib.parse import urljoin
 
 import pytest
@@ -13,6 +14,7 @@ from integration.conftest import deploy  # noqa: F401, pylint: disable=W0611
 from integration.helpers import (
     APP_NAME,
     HAPROXY_NAME,
+    PRO_AIRGAPPED_SERVER_NAME,
     get_unit_url,
     scale,
     simulate_charm_redeploy,
@@ -29,17 +31,26 @@ class TestDeployment:
 
     async def assert_http(
         self, ops_test: OpsTest, protocol: str, application: str, unit: int, port: int, path: str = ""
-    ):
-        """Call given HTTP endpoint and assert if the call was successful (HTTP 200)"""
+    ) -> str:
+        """
+        Call given HTTP endpoint and assert if the call was successful (HTTP 200)
+
+        The method returns the response body as a string.
+        """
         unit_url = await get_unit_url(ops_test, protocol=protocol, application=application, unit=unit, port=port)
         u = urljoin(unit_url, path)
         logger.info("curling app address: %s", u)
         response = requests.get(u, timeout=300, verify=False)  # nosec
         assert response.status_code == 200
+        return response.content.decode()
 
-    async def assert_livepatch_server_healthy(self, ops_test: OpsTest, unit: int = 0):
-        """Perform `GET debug/status`request on the Livepatch unit."""
-        await self.assert_http(
+    async def assert_livepatch_server_healthy(self, ops_test: OpsTest, unit: int = 0) -> dict:
+        """
+        Perform `GET debug/status`request on the Livepatch unit.
+
+        The method returns the HTTP response as a dict.
+        """
+        result = await self.assert_http(
             ops_test,
             protocol="http",
             application=APP_NAME,
@@ -47,10 +58,15 @@ class TestDeployment:
             port=8080,
             path="debug/status",
         )
+        return json.loads(result)
 
-    async def assert_ha_proxy_healthy(self, ops_test: OpsTest, unit: int = 0):
-        """Perform `GET debug/status`request on HAProxy unit."""
-        await self.assert_http(
+    async def assert_ha_proxy_healthy(self, ops_test: OpsTest, unit: int = 0) -> dict:
+        """
+        Perform `GET debug/status`request on HAProxy unit.
+
+        The method returns the HTTP response as a dict.
+        """
+        result = await self.assert_http(
             ops_test,
             protocol="http",
             application=HAPROXY_NAME,
@@ -58,6 +74,7 @@ class TestDeployment:
             port=80,
             path="debug/status",
         )
+        return json.loads(result)
 
     async def test_livepatch_server(self, ops_test: OpsTest):
         """Assert Livepatch server (unit=0) is healthy."""
@@ -87,3 +104,37 @@ class TestDeployment:
         await scale(application_name=APP_NAME, ops_test=ops_test, count=1)
         await self.assert_livepatch_server_healthy(ops_test, unit=0)
         await self.assert_ha_proxy_healthy(ops_test, unit=0)
+
+    async def test_integration_with_pro_airgapped_server(self, ops_test: OpsTest):
+        """Test integration with pro-airgapped-server."""
+        await self.assert_livepatch_server_healthy(ops_test, unit=0)
+        await self.assert_ha_proxy_healthy(ops_test, unit=0)
+
+        async with ops_test.fast_forward():
+            await ops_test.model.deploy(
+                PRO_AIRGAPPED_SERVER_NAME,
+                num_units=1,
+                config={
+                    # Since we don't have a dummy yet valid Pro token, we use the following
+                    # override mechanism to bypass the validation step. The token and the
+                    # override are taken from happy-path tests of the underlying project.
+                    "pro-token": "C14LZCAxz36w6Nh5EQDuD6cmNKtwWn",
+                    "conf-override": "QzE0TFpDQXh6MzZ3Nk5oNUVRRHVENmNtTkt0d1duOgogIGFjY291bnRJbmZvOgogICAgY3JlYXRlZEF0OiAiMjAyMi0wNS0xMlQwNjoyNzowM1oiCiAgICBpZDogYUFQWXc3M3hHCiAgICBuYW1lOiBhLmJAZXhhbXBsZS5jb20KICAgIHR5cGU6IHBlcnNvbmFsCiAgY29udHJhY3RJbmZvOgogICAgYWxsb3dhbmNlczoKICAgIC0gbWV0cmljOiB1bml0cwogICAgICB2YWx1ZTogMwogICAgY3JlYXRlZEF0OiAiMjAyMi0wNS0xMlQwNjoyNzowNFoiCiAgICBjcmVhdGVkQnk6ICIiCiAgICBlZmZlY3RpdmVGcm9tOiAiMjAyMi0wNS0xMlQwNjoyNzowNFoiCiAgICBlZmZlY3RpdmVUbzogIjk5OTktMTItMzFUMDA6MDA6MDBaIgogICAgaWQ6IGNBWC0tb05kCiAgICBpdGVtczoKICAgIC0gY29udHJhY3RJRDogY0FYLS1vTmQKICAgICAgY3JlYXRlZDogIjIwMjItMDUtMTJUMDY6Mjc6MDRaIgogICAgICBlZmZlY3RpdmVGcm9tOiAiMjAyMi0wNS0xMlQwNjoyNzowNFoiCiAgICAgIGVmZmVjdGl2ZVRvOiAiOTk5OS0xMi0zMVQwMDowMDowMFoiCiAgICAgIGV4dGVybmFsSURzOiBudWxsCiAgICAgIGlkOiAzOTYyOTAKICAgICAgbGFzdE1vZGlmaWVkOiAiMjAyMi0wNS0xMlQwNjoyNzowNFoiCiAgICAgIG1ldHJpYzogdW5pdHMKICAgICAgcmVhc29uOiBjb250cmFjdF9jcmVhdGVkCiAgICAgIHZhbHVlOiAzCiAgICBuYW1lOiBhLmJAZXhhbXBsZS5jb20KICAgIG9yaWdpbjogZnJlZQogICAgcHJvZHVjdHM6CiAgICAtIGZyZWUKICAgIHJlc291cmNlRW50aXRsZW1lbnRzOgogICAgLSBhZmZvcmRhbmNlczoKICAgICAgICBhcmNoaXRlY3R1cmVzOgogICAgICAgIC0gYW1kNjQKICAgICAgICAtIHg4Nl82NAogICAgICAgIHNlcmllczoKICAgICAgICAtIHhlbmlhbAogICAgICAgIC0gYmlvbmljCiAgICAgIGRpcmVjdGl2ZXM6CiAgICAgICAgYWRkaXRpb25hbFBhY2thZ2VzOgogICAgICAgIC0gdWJ1bnR1LWNvbW1vbmNyaXRlcmlhCiAgICAgICAgYXB0S2V5OiA5RjkxMkRBREQ5OUVFMUNDNkJGRkZGMjQzQTE4NkU3MzNGNDkxQzQ2CiAgICAgICAgYXB0VVJMOiBodHRwczovL2VzbS51YnVudHUuY29tL2NjCiAgICAgICAgc3VpdGVzOgogICAgICAgIC0geGVuaWFsCiAgICAgICAgLSBiaW9uaWMKICAgICAgZW50aXRsZWQ6IHRydWUKICAgICAgb2JsaWdhdGlvbnM6CiAgICAgICAgZW5hYmxlQnlEZWZhdWx0OiBmYWxzZQogICAgICB0eXBlOiBjYy1lYWw=",  # noqa: E501
+                },
+            )
+            logger.info("Waiting for pro-airgapped-server")
+            await ops_test.model.wait_for_idle(
+                apps=[PRO_AIRGAPPED_SERVER_NAME], status="active", raise_on_blocked=False, timeout=600
+            )
+            logger.info("Integrating Livepatch and pro-airgapped-server")
+            await ops_test.model.integrate(
+                f"{APP_NAME}:pro-airgapped-server", f"{PRO_AIRGAPPED_SERVER_NAME}:livepatch-server"
+            )
+            logger.info("Waiting for Livepatch")
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME, PRO_AIRGAPPED_SERVER_NAME], status="active", raise_on_blocked=False, timeout=600
+            )
+
+        status = await self.assert_ha_proxy_healthy(ops_test, unit=0)
+        logger.error("/debug/status: %s",json.dumps(status))
+        assert status["contracts"]["status"] == "OK"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -115,7 +115,7 @@ class TestDeployment:
                 PRO_AIRGAPPED_SERVER_NAME,
                 num_units=1,
                 config={
-                    # Since we don't have a dummy yet valid Pro token, we use the following
+                    # Since we don't have a fake yet valid Pro token, we use the following
                     # override mechanism to bypass the validation step. The token and the
                     # override are taken from happy-path tests of the underlying project.
                     "pro-token": "C14LZCAxz36w6Nh5EQDuD6cmNKtwWn",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -136,5 +136,4 @@ class TestDeployment:
             )
 
         status = await self.assert_ha_proxy_healthy(ops_test, unit=0)
-        logger.error("/debug/status: %s",json.dumps(status))
         assert status["contracts"]["status"] == "OK"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -467,7 +467,6 @@ class TestCharm(unittest.TestCase):
 
     def test_install(self):
         """test install event handler."""
-
         self.snap_mock.present = False
         self.snap_mock.services = {"livepatch": {"active": False}}
         self.snap_mock.ensure.return_value = None
@@ -499,7 +498,6 @@ class TestCharm(unittest.TestCase):
 
     def test_install__already_installed(self):
         """test install event handler, when the livepatch snap is already installed."""
-
         self.snap_mock.present = True
         self.snap_mock.services = {"livepatch": {"active": False}}
         self.snap_mock.set.return_value = None
@@ -529,7 +527,6 @@ class TestCharm(unittest.TestCase):
 
     def start_leader_unit(self, relate_to_pro_airgapped_server: bool = False):
         """starts leader unit by doing a full configuration/integration."""
-
         self.snap_mock.present = True
         self.snap_mock.services = {"livepatch": {"active": False}}
         self.snap_mock.set.return_value = None
@@ -643,7 +640,6 @@ class TestCharm(unittest.TestCase):
 
     def test_enable_action__success(self):
         """test `enable` action."""
-
         self.start_leader_unit()
         self.snap_mock.get.return_value = "some-token"
 
@@ -655,7 +651,6 @@ class TestCharm(unittest.TestCase):
 
     def test_enable_action__empty_token(self):
         """test `enable` action when provided token is empty."""
-
         self.start_leader_unit()
 
         with self.assertRaises(ActionFailed) as ex:
@@ -665,7 +660,6 @@ class TestCharm(unittest.TestCase):
 
     def test_enable_action__empty_retrieved_token(self):
         """test `enable` action when provided token cannot be set in the snap's configuration."""
-
         self.start_leader_unit()
         self.snap_mock.get.return_value = ""  # retrieved token
 
@@ -676,7 +670,6 @@ class TestCharm(unittest.TestCase):
 
     def test_enable_action__snap_not_installed(self):
         """test `enable` action when livepatch snap is not installed."""
-
         self.snap_mock.present = False
 
         with self.assertRaises(ActionFailed) as ex:
@@ -686,7 +679,6 @@ class TestCharm(unittest.TestCase):
 
     def test_restart_action__success(self):
         """test `restart` action."""
-
         self.start_leader_unit()
         self.snap_mock.services = {"livepatch": {"active": False}}  # mark service as stopped
 
@@ -702,7 +694,6 @@ class TestCharm(unittest.TestCase):
 
     def test_restart_action__failed_restart(self):
         """test `restart` action when service is not running after restart."""
-
         self.start_leader_unit()
         self.snap_mock.services = {"livepatch": {"active": False}}  # mark service as stopped
         self.snap_mock.restart = Mock(return_value=None)
@@ -715,7 +706,6 @@ class TestCharm(unittest.TestCase):
 
     def test_restart_action__snap_not_installed(self):
         """test `restart` action when snap is not installed."""
-
         self.start_leader_unit()
         self.snap_mock.present = False
 
@@ -728,7 +718,6 @@ class TestCharm(unittest.TestCase):
 
     def test_schema_upgrade_action__success(self):
         """test `schema-upgrade` action."""
-
         self.snap_mock.present = True
         self.snap_mock.services = {"livepatch": {"active": False}}
         self.snap_mock.set.return_value = None
@@ -792,7 +781,6 @@ class TestCharm(unittest.TestCase):
 
     def test_schema_upgrade_action__failed(self):
         """test `schema-upgrade` action failure."""
-
         self.snap_mock.present = True
         self.snap_mock.services = {"livepatch": {"active": False}}
         self.snap_mock.set.return_value = None
@@ -851,7 +839,6 @@ class TestCharm(unittest.TestCase):
 
     def test_set_basic_users_action__success(self):
         """test `set-basic-users` action."""
-
         self.start_leader_unit()
 
         self.snap_mock.set = Mock(return_value=None)
@@ -901,7 +888,6 @@ class TestCharm(unittest.TestCase):
 
     def test_set_basic_users_action__repeated_user(self):
         """test `set-basic-users` action when an existing user is re-added."""
-
         self.start_leader_unit()
 
         self.snap_mock.set = Mock(return_value=None)
@@ -943,7 +929,6 @@ class TestCharm(unittest.TestCase):
 
     def test_set_basic_users_action__long_password(self):
         """test `set-basic-users` action when password is longer than allowed."""
-
         self.start_leader_unit()
 
         self.snap_mock.set = Mock(return_value=None)
@@ -966,9 +951,7 @@ class TestCharm(unittest.TestCase):
 
     def test_set_basic_users_action__invalid_arg(self):
         """test `set-basic-users` action when argument is not valid."""
-
         self.start_leader_unit()
-
         with self.subTest("users: none"):
             with self.assertRaises(ActionFailed) as ex:
                 self.harness.run_action("set-basic-users", {"users": None})
@@ -995,7 +978,6 @@ class TestCharm(unittest.TestCase):
 
     def test_custom_ca(self):
         """test setting a custom CA for the contracts server"""
-
         self.start_leader_unit()
         with tempfile.NamedTemporaryFile() as tmpfile:
             with patch.object(src.charm, "TRUSTED_CA_FILENAME", tmpfile.name):

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,6 @@ commands =
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
     pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120,W0511,C0415
 
-
 [testenv:fmt]
 skip_install=True
 description = run formatters
@@ -90,10 +89,8 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v {posargs}
+        -m pytest {[vars]tst_path}unit -v {posargs}
     coverage report
-
-
 
 [testenv:integration]
 description = Run integration tests
@@ -105,4 +102,4 @@ deps =
     requests
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
This PR adds integration with `pro-airgapped-server` charm.

Fixes CSS-9566

**NOTE:** Before merging this we need to:
- Merge canonical/livepatch-server#1138 and publish the snap package, so that the charm can use it.
- Update the `SERVER_SNAP_REVISION` (in `src/constants/snap.py`) to match the published snap.