### PR TITLE
update bundle and postgres lib

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,13 +1,5 @@
 header:
   - license:
-      copyright-owner: Canonical Ltd.
-      content: |
-        Copyright [year] [owner]
-        Licensed under the Apache2.0. See LICENSE file in charm source for details.
-    paths:
-      - 'lib/**'
-    comment: on-failure
-  - license:
       spdx-id: Apache-2.0
       copyright-owner: Canonical Ltd.
       content: |

--- a/bundle/bundle.yaml
+++ b/bundle/bundle.yaml
@@ -16,12 +16,12 @@ applications:
     charm: ch:postgresql
     channel: 14/stable
     num_units: 1
-    constraints: cpu-cores=1 mem=4G root-disk=50G
+    constraints: cpu-cores=2 mem=4G root-disk=50G
   livepatch:
     charm: ch:canonical-livepatch-server
-    channel: ops1.x/edge
+    channel: ops1.x/stable
     num_units: 1
-    constraints: cpu-cores=1 mem=2G root-disk=50G
+    constraints: cpu-cores=2 mem=4G root-disk=50G
     options:
       patch-storage.type: postgres
   haproxy:

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1,6 +1,16 @@
-# Copyright 2024 Canonical Ltd.
-# Licensed under the Apache2.0. See LICENSE file in charm source for details.
-
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 r"""Library to manage the relation for the data-platform products.
 
@@ -285,12 +295,23 @@ import copy
 import json
 import logging
 from abc import ABC, abstractmethod
-from collections import namedtuple
+from collections import UserDict, namedtuple
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    ItemsView,
+    KeysView,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    ValuesView,
+)
 
-from ops import JujuVersion, Secret, SecretInfo, SecretNotFoundError
+from ops import JujuVersion, Model, Secret, SecretInfo, SecretNotFoundError
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -310,9 +331,13 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 24
+LIBPATCH = 40
 
 PYDEPS = ["ops>=2.0.0"]
+
+# Starting from what LIBPATCH number to apply legacy solutions
+# v0.17 was the last version without secrets
+LEGACY_SUPPORT_FROM = 17
 
 logger = logging.getLogger(__name__)
 
@@ -327,31 +352,26 @@ deleted - key that were deleted"""
 
 PROV_SECRET_PREFIX = "secret-"
 REQ_SECRET_FIELDS = "requested-secrets"
+GROUP_MAPPING_FIELD = "secret_group_mapping"
+GROUP_SEPARATOR = "@"
 
-
-class SecretGroup(Enum):
-    """Secret groups as constants."""
-
-    USER = "user"
-    TLS = "tls"
-    EXTRA = "extra"
-
-
-# Local map to associate mappings with secrets potentially as a group
-SECRET_LABEL_MAP = {
-    "username": SecretGroup.USER,
-    "password": SecretGroup.USER,
-    "uris": SecretGroup.USER,
-    "tls": SecretGroup.TLS,
-    "tls-ca": SecretGroup.TLS,
+MODEL_ERRORS = {
+    "not_leader": "this unit is not the leader",
+    "no_label_and_uri": "ERROR either URI or label should be used for getting an owned secret but not both",
+    "owner_no_refresh": "ERROR secret owner cannot use --refresh",
 }
+
+
+##############################################################################
+# Exceptions
+##############################################################################
 
 
 class DataInterfacesError(Exception):
     """Common ancestor for DataInterfaces related exceptions."""
 
 
-class SecretError(Exception):
+class SecretError(DataInterfacesError):
     """Common ancestor for Secrets related exceptions."""
 
 
@@ -367,7 +387,26 @@ class SecretsIllegalUpdateError(SecretError):
     """Secrets aren't yet available for Juju version used."""
 
 
-def get_encoded_dict(relation: Relation, member: Union[Unit, Application], field: str) -> Optional[Dict[str, str]]:
+class IllegalOperationError(DataInterfacesError):
+    """To be used when an operation is not allowed to be performed."""
+
+
+class PrematureDataAccessError(DataInterfacesError):
+    """To be raised when the Relation Data may be accessed (written) before protocol init complete."""
+
+
+##############################################################################
+# Global helpers / utilities
+##############################################################################
+
+##############################################################################
+# Databag handling and comparison methods
+##############################################################################
+
+
+def get_encoded_dict(
+    relation: Relation, member: Union[Unit, Application], field: str
+) -> Optional[Dict[str, str]]:
     """Retrieve and decode an encoded field from relation data."""
     data = json.loads(relation.data[member].get(field, "{}"))
     if isinstance(data, dict):
@@ -375,7 +414,9 @@ def get_encoded_dict(relation: Relation, member: Union[Unit, Application], field
     logger.error("Unexpected datatype for %s instead of dict.", str(data))
 
 
-def get_encoded_list(relation: Relation, member: Union[Unit, Application], field: str) -> Optional[List[str]]:
+def get_encoded_list(
+    relation: Relation, member: Union[Unit, Application], field: str
+) -> Optional[List[str]]:
     """Retrieve and decode an encoded field from relation data."""
     data = json.loads(relation.data[member].get(field, "[]"))
     if isinstance(data, list):
@@ -393,7 +434,7 @@ def set_encoded_field(
     relation.data[member].update({field: json.dumps(value)})
 
 
-def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
+def diff(event: RelationChangedEvent, bucket: Optional[Union[Unit, Application]]) -> Diff:
     """Retrieves the diff of the data in the relation changed databag.
 
     Args:
@@ -405,6 +446,9 @@ def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
             keys from the event relation databag.
     """
     # Retrieve the old data from the data key in the application relation databag.
+    if not bucket:
+        return Diff([], [], [])
+
     old_data = get_encoded_dict(event.relation, bucket, "data")
 
     if not old_data:
@@ -412,19 +456,21 @@ def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
 
     # Retrieve the new data from the event relation databag.
     new_data = (
-        {key: value for key, value in event.relation.data[event.app].items() if key != "data"} if event.app else {}
+        {key: value for key, value in event.relation.data[event.app].items() if key != "data"}
+        if event.app
+        else {}
     )
 
     # These are the keys that were added to the databag and triggered this event.
-    added = new_data.keys() - old_data.keys()  # pyright: ignore [reportGeneralTypeIssues]
+    added = new_data.keys() - old_data.keys()  # pyright: ignore [reportAssignmentType]
     # These are the keys that were removed from the databag and triggered this event.
-    deleted = old_data.keys() - new_data.keys()  # pyright: ignore [reportGeneralTypeIssues]
+    deleted = old_data.keys() - new_data.keys()  # pyright: ignore [reportAssignmentType]
     # These are the keys that already existed in the databag,
     # but had their values changed.
     changed = {
         key
-        for key in old_data.keys() & new_data.keys()  # pyright: ignore [reportGeneralTypeIssues]
-        if old_data[key] != new_data[key]  # pyright: ignore [reportGeneralTypeIssues]
+        for key in old_data.keys() & new_data.keys()  # pyright: ignore [reportAssignmentType]
+        if old_data[key] != new_data[key]  # pyright: ignore [reportAssignmentType]
     }
     # Convert the new_data to a serializable format and save it for a next diff check.
     set_encoded_field(event.relation, bucket, "data", new_data)
@@ -433,15 +479,23 @@ def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
     return Diff(added, changed, deleted)
 
 
+##############################################################################
+# Module decorators
+##############################################################################
+
+
 def leader_only(f):
     """Decorator to ensure that only leader can perform given operation."""
 
     def wrapper(self, *args, **kwargs):
-        if not self.local_unit.is_leader():
-            logger.error("This operation (%s()) can only be performed by the leader unit", f.__name__)
+        if self.component == self.local_app and not self.local_unit.is_leader():
+            logger.error(
+                "This operation (%s()) can only be performed by the leader unit", f.__name__
+            )
             return
         return f(self, *args, **kwargs)
 
+    wrapper.leader_only = True
     return wrapper
 
 
@@ -456,11 +510,100 @@ def juju_secrets_only(f):
     return wrapper
 
 
+def dynamic_secrets_only(f):
+    """Decorator to ensure that certain operations would be only executed when NO static secrets are defined."""
+
+    def wrapper(self, *args, **kwargs):
+        if self.static_secret_fields:
+            raise IllegalOperationError(
+                "Unsafe usage of statically and dynamically defined secrets, aborting."
+            )
+        return f(self, *args, **kwargs)
+
+    return wrapper
+
+
+def either_static_or_dynamic_secrets(f):
+    """Decorator to ensure that static and dynamic secrets won't be used in parallel."""
+
+    def wrapper(self, *args, **kwargs):
+        if self.static_secret_fields and set(self.current_secret_fields) - set(
+            self.static_secret_fields
+        ):
+            raise IllegalOperationError(
+                "Unsafe usage of statically and dynamically defined secrets, aborting."
+            )
+        return f(self, *args, **kwargs)
+
+    return wrapper
+
+
+def legacy_apply_from_version(version: int) -> Callable:
+    """Decorator to decide whether to apply a legacy function or not.
+
+    Based on LEGACY_SUPPORT_FROM module variable value, the importer charm may only want
+    to apply legacy solutions starting from a specific LIBPATCH.
+
+    NOTE: All 'legacy' functions have to be defined and called in a way that they return `None`.
+    This results in cleaner and more secure execution flows in case the function may be disabled.
+    This requirement implicitly means that legacy functions change the internal state strictly,
+    don't return information.
+    """
+
+    def decorator(f: Callable[..., None]):
+        """Signature is ensuring None return value."""
+        f.legacy_version = version
+
+        def wrapper(self, *args, **kwargs) -> None:
+            if version >= LEGACY_SUPPORT_FROM:
+                return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+##############################################################################
+# Helper classes
+##############################################################################
+
+
 class Scope(Enum):
     """Peer relations scope."""
 
     APP = "app"
     UNIT = "unit"
+
+
+class SecretGroup(str):
+    """Secret groups specific type."""
+
+
+class SecretGroupsAggregate(str):
+    """Secret groups with option to extend with additional constants."""
+
+    def __init__(self):
+        self.USER = SecretGroup("user")
+        self.TLS = SecretGroup("tls")
+        self.EXTRA = SecretGroup("extra")
+
+    def __setattr__(self, name, value):
+        """Setting internal constants."""
+        if name in self.__dict__:
+            raise RuntimeError("Can't set constant!")
+        else:
+            super().__setattr__(name, SecretGroup(value))
+
+    def groups(self) -> list:
+        """Return the list of stored SecretGroups."""
+        return list(self.__dict__.values())
+
+    def get_group(self, group: str) -> Optional[SecretGroup]:
+        """If the input str translates to a group name, return that."""
+        return SecretGroup(group) if group in self.groups() else None
+
+
+SECRET_GROUPS = SecretGroupsAggregate()
 
 
 class CachedSecret:
@@ -469,23 +612,24 @@ class CachedSecret:
     The data structure is precisely re-using/simulating as in the actual Secret Storage
     """
 
-    def __init__(self, charm: CharmBase, label: str, secret_uri: Optional[str] = None):
+    KNOWN_MODEL_ERRORS = [MODEL_ERRORS["no_label_and_uri"], MODEL_ERRORS["owner_no_refresh"]]
+
+    def __init__(
+        self,
+        model: Model,
+        component: Union[Application, Unit],
+        label: str,
+        secret_uri: Optional[str] = None,
+        legacy_labels: List[str] = [],
+    ):
         self._secret_meta = None
         self._secret_content = {}
         self._secret_uri = secret_uri
         self.label = label
-        self.charm = charm
-
-    def add_secret(self, content: Dict[str, str], relation: Relation) -> Secret:
-        """Create a new secret."""
-        if self._secret_uri:
-            raise SecretAlreadyExistsError("Secret is already defined with uri %s", self._secret_uri)
-
-        secret = self.charm.app.add_secret(content, label=self.label)
-        secret.grant(relation)
-        self._secret_uri = secret.id
-        self._secret_meta = secret
-        return self._secret_meta
+        self._model = model
+        self.component = component
+        self.legacy_labels = legacy_labels
+        self.current_label = None
 
     @property
     def meta(self) -> Optional[Secret]:
@@ -493,11 +637,109 @@ class CachedSecret:
         if not self._secret_meta:
             if not (self._secret_uri or self.label):
                 return
+
             try:
-                self._secret_meta = self.charm.model.get_secret(label=self.label)
+                self._secret_meta = self._model.get_secret(label=self.label)
             except SecretNotFoundError:
-                if self._secret_uri:
-                    self._secret_meta = self.charm.model.get_secret(id=self._secret_uri, label=self.label)
+                # Falling back to seeking for potential legacy labels
+                self._legacy_compat_find_secret_by_old_label()
+
+            # If still not found, to be checked by URI, to be labelled with the proposed label
+            if not self._secret_meta and self._secret_uri:
+                self._secret_meta = self._model.get_secret(id=self._secret_uri, label=self.label)
+        return self._secret_meta
+
+    ##########################################################################
+    # Backwards compatibility / Upgrades
+    ##########################################################################
+    # These functions are used to keep backwards compatibility on rolling upgrades
+    # Policy:
+    # All data is kept intact until the first write operation. (This allows a minimal
+    # grace period during which rollbacks are fully safe. For more info see the spec.)
+    # All data involves:
+    #   - databag contents
+    #   - secrets content
+    #   - secret labels (!!!)
+    # Legacy functions must return None, and leave an equally consistent state whether
+    # they are executed or skipped (as a high enough versioned execution environment may
+    # not require so)
+
+    # Compatibility
+
+    @legacy_apply_from_version(34)
+    def _legacy_compat_find_secret_by_old_label(self) -> None:
+        """Compatibility function, allowing to find a secret by a legacy label.
+
+        This functionality is typically needed when secret labels changed over an upgrade.
+        Until the first write operation, we need to maintain data as it was, including keeping
+        the old secret label. In order to keep track of the old label currently used to access
+        the secret, and additional 'current_label' field is being defined.
+        """
+        for label in self.legacy_labels:
+            try:
+                self._secret_meta = self._model.get_secret(label=label)
+            except SecretNotFoundError:
+                pass
+            else:
+                if label != self.label:
+                    self.current_label = label
+                return
+
+    # Migrations
+
+    @legacy_apply_from_version(34)
+    def _legacy_migration_to_new_label_if_needed(self) -> None:
+        """Helper function to re-create the secret with a different label.
+
+        Juju does not provide a way to change secret labels.
+        Thus whenever moving from secrets version that involves secret label changes,
+        we "re-create" the existing secret, and attach the new label to the new
+        secret, to be used from then on.
+
+        Note: we replace the old secret with a new one "in place", as we can't
+        easily switch the containing SecretCache structure to point to a new secret.
+        Instead we are changing the 'self' (CachedSecret) object to point to the
+        new instance.
+        """
+        if not self.current_label or not (self.meta and self._secret_meta):
+            return
+
+        # Create a new secret with the new label
+        content = self._secret_meta.get_content()
+        self._secret_uri = None
+
+        # It will be nice to have the possibility to check if we are the owners of the secret...
+        try:
+            self._secret_meta = self.add_secret(content, label=self.label)
+        except ModelError as err:
+            if MODEL_ERRORS["not_leader"] not in str(err):
+                raise
+        self.current_label = None
+
+    ##########################################################################
+    # Public functions
+    ##########################################################################
+
+    def add_secret(
+        self,
+        content: Dict[str, str],
+        relation: Optional[Relation] = None,
+        label: Optional[str] = None,
+    ) -> Secret:
+        """Create a new secret."""
+        if self._secret_uri:
+            raise SecretAlreadyExistsError(
+                "Secret is already defined with uri %s", self._secret_uri
+            )
+
+        label = self.label if not label else label
+
+        secret = self.component.add_secret(content, label=label)
+        if relation and relation.app != self._model.app:
+            # If it's not a peer relation, grant is to be applied
+            secret.grant(relation)
+        self._secret_uri = secret.id
+        self._secret_meta = secret
         return self._secret_meta
 
     def get_content(self) -> Dict[str, str]:
@@ -509,8 +751,9 @@ class CachedSecret:
                 except (ValueError, ModelError) as err:
                     # https://bugs.launchpad.net/juju/+bug/2042596
                     # Only triggered when 'refresh' is set
-                    msg = "ERROR either URI or label should be used for getting an owned secret but not both"
-                    if isinstance(err, ModelError) and msg not in str(err):
+                    if isinstance(err, ModelError) and not any(
+                        msg in str(err) for msg in self.KNOWN_MODEL_ERRORS
+                    ):
                         raise
                     # Due to: ValueError: Secret owner cannot use refresh=True
                     self._secret_content = self.meta.get_content()
@@ -521,7 +764,12 @@ class CachedSecret:
         if not self.meta:
             return
 
+        # DPE-4182: do not create new revision if the content stay the same
+        if content == self.get_content():
+            return
+
         if content:
+            self._legacy_migration_to_new_label_if_needed()
             self.meta.set_content(content)
             self._secret_content = content
         else:
@@ -532,18 +780,35 @@ class CachedSecret:
         if self.meta:
             return self.meta.get_info()
 
+    def remove(self) -> None:
+        """Remove secret."""
+        if not self.meta:
+            raise SecretsUnavailableError("Non-existent secret was attempted to be removed.")
+        try:
+            self.meta.remove_all_revisions()
+        except SecretNotFoundError:
+            pass
+        self._secret_content = {}
+        self._secret_meta = None
+        self._secret_uri = None
+
 
 class SecretCache:
     """A data structure storing CachedSecret objects."""
 
-    def __init__(self, charm):
-        self.charm = charm
+    def __init__(self, model: Model, component: Union[Application, Unit]):
+        self._model = model
+        self.component = component
         self._secrets: Dict[str, CachedSecret] = {}
 
-    def get(self, label: str, uri: Optional[str] = None) -> Optional[CachedSecret]:
+    def get(
+        self, label: str, uri: Optional[str] = None, legacy_labels: List[str] = []
+    ) -> Optional[CachedSecret]:
         """Getting a secret from Juju Secret store or cache."""
         if not self._secrets.get(label):
-            secret = CachedSecret(self.charm, label, uri)
+            secret = CachedSecret(
+                self._model, self.component, label, uri, legacy_labels=legacy_labels
+            )
             if secret.meta:
                 self._secrets[label] = secret
         return self._secrets.get(label)
@@ -553,37 +818,172 @@ class SecretCache:
         if self._secrets.get(label):
             raise SecretAlreadyExistsError(f"Secret {label} already exists")
 
-        secret = CachedSecret(self.charm, label)
+        secret = CachedSecret(self._model, self.component, label)
         secret.add_secret(content, relation)
         self._secrets[label] = secret
         return self._secrets[label]
 
+    def remove(self, label: str) -> None:
+        """Remove a secret from the cache."""
+        if secret := self.get(label):
+            try:
+                secret.remove()
+                self._secrets.pop(label)
+            except (SecretsUnavailableError, KeyError):
+                pass
+            else:
+                return
+        logging.debug("Non-existing Juju Secret was attempted to be removed %s", label)
 
-# Base DataRelation
+
+################################################################################
+# Relation Data base/abstract ancestors (i.e. parent classes)
+################################################################################
 
 
-class DataRelation(Object, ABC):
+# Base Data
+
+
+class DataDict(UserDict):
+    """Python Standard Library 'dict' - like representation of Relation Data."""
+
+    def __init__(self, relation_data: "Data", relation_id: int):
+        self.relation_data = relation_data
+        self.relation_id = relation_id
+
+    @property
+    def data(self) -> Dict[str, str]:
+        """Return the full content of the Abstract Relation Data dictionary."""
+        result = self.relation_data.fetch_my_relation_data([self.relation_id])
+        try:
+            result_remote = self.relation_data.fetch_relation_data([self.relation_id])
+        except NotImplementedError:
+            result_remote = {self.relation_id: {}}
+        if result:
+            result_remote[self.relation_id].update(result[self.relation_id])
+        return result_remote.get(self.relation_id, {})
+
+    def __setitem__(self, key: str, item: str) -> None:
+        """Set an item of the Abstract Relation Data dictionary."""
+        self.relation_data.update_relation_data(self.relation_id, {key: item})
+
+    def __getitem__(self, key: str) -> str:
+        """Get an item of the Abstract Relation Data dictionary."""
+        result = None
+
+        # Avoiding "leader_only" error when cross-charm non-leader unit, not to report useless error
+        if (
+            not hasattr(self.relation_data.fetch_my_relation_field, "leader_only")
+            or self.relation_data.component != self.relation_data.local_app
+            or self.relation_data.local_unit.is_leader()
+        ):
+            result = self.relation_data.fetch_my_relation_field(self.relation_id, key)
+
+        if not result:
+            try:
+                result = self.relation_data.fetch_relation_field(self.relation_id, key)
+            except NotImplementedError:
+                pass
+
+        if not result:
+            raise KeyError
+        return result
+
+    def __eq__(self, d: dict) -> bool:
+        """Equality."""
+        return self.data == d
+
+    def __repr__(self) -> str:
+        """String representation Abstract Relation Data dictionary."""
+        return repr(self.data)
+
+    def __len__(self) -> int:
+        """Length of the Abstract Relation Data dictionary."""
+        return len(self.data)
+
+    def __delitem__(self, key: str) -> None:
+        """Delete an item of the Abstract Relation Data dictionary."""
+        self.relation_data.delete_relation_data(self.relation_id, [key])
+
+    def has_key(self, key: str) -> bool:
+        """Does the key exist in the Abstract Relation Data dictionary?"""
+        return key in self.data
+
+    def update(self, items: Dict[str, str]):
+        """Update the Abstract Relation Data dictionary."""
+        self.relation_data.update_relation_data(self.relation_id, items)
+
+    def keys(self) -> KeysView[str]:
+        """Keys of the Abstract Relation Data dictionary."""
+        return self.data.keys()
+
+    def values(self) -> ValuesView[str]:
+        """Values of the Abstract Relation Data dictionary."""
+        return self.data.values()
+
+    def items(self) -> ItemsView[str, str]:
+        """Items of the Abstract Relation Data dictionary."""
+        return self.data.items()
+
+    def pop(self, item: str) -> str:
+        """Pop an item of the Abstract Relation Data dictionary."""
+        result = self.relation_data.fetch_my_relation_field(self.relation_id, item)
+        if not result:
+            raise KeyError(f"Item {item} doesn't exist.")
+        self.relation_data.delete_relation_data(self.relation_id, [item])
+        return result
+
+    def __contains__(self, item: str) -> bool:
+        """Does the Abstract Relation Data dictionary contain item?"""
+        return item in self.data.values()
+
+    def __iter__(self):
+        """Iterate through the Abstract Relation Data dictionary."""
+        return iter(self.data)
+
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        """Safely get an item of the Abstract Relation Data dictionary."""
+        try:
+            if result := self[key]:
+                return result
+        except KeyError:
+            return default
+
+
+class Data(ABC):
     """Base relation data mainpulation (abstract) class."""
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
-        self.charm = charm
-        self.local_app = self.charm.model.app
-        self.local_unit = self.charm.unit
+    SCOPE = Scope.APP
+
+    # Local map to associate mappings with secrets potentially as a group
+    SECRET_LABEL_MAP = {
+        "username": SECRET_GROUPS.USER,
+        "password": SECRET_GROUPS.USER,
+        "uris": SECRET_GROUPS.USER,
+        "tls": SECRET_GROUPS.TLS,
+        "tls-ca": SECRET_GROUPS.TLS,
+    }
+
+    def __init__(
+        self,
+        model: Model,
+        relation_name: str,
+    ) -> None:
+        self._model = model
+        self.local_app = self._model.app
+        self.local_unit = self._model.unit
         self.relation_name = relation_name
-        self.framework.observe(
-            charm.on[relation_name].relation_changed,
-            self._on_relation_changed_event,
-        )
         self._jujuversion = None
-        self.secrets = SecretCache(self.charm)
+        self.component = self.local_app if self.SCOPE == Scope.APP else self.local_unit
+        self.secrets = SecretCache(self._model, self.component)
+        self.data_component = None
 
     @property
     def relations(self) -> List[Relation]:
         """The list of Relation instances associated with this relation_name."""
         return [
             relation
-            for relation in self.charm.model.relations[self.relation_name]
+            for relation in self._model.relations[self.relation_name]
             if self._is_relation_active(relation)
         ]
 
@@ -594,12 +994,12 @@ class DataRelation(Object, ABC):
             self._jujuversion = JujuVersion.from_environ()
         return self._jujuversion.has_secrets
 
-    # Mandatory overrides for internal/helper methods
+    @property
+    def secret_label_map(self):
+        """Exposing secret-label map via a property -- could be overridden in descendants!"""
+        return self.SECRET_LABEL_MAP
 
-    @abstractmethod
-    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation data has changed."""
-        raise NotImplementedError
+    # Mandatory overrides for internal/helper methods
 
     @abstractmethod
     def _get_relation_secret(
@@ -609,12 +1009,16 @@ class DataRelation(Object, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _fetch_specific_relation_data(self, relation: Relation, fields: Optional[List[str]]) -> Dict[str, str]:
+    def _fetch_specific_relation_data(
+        self, relation: Relation, fields: Optional[List[str]]
+    ) -> Dict[str, str]:
         """Fetch data available (directily or indirectly -- i.e. secrets) from the relation."""
         raise NotImplementedError
 
     @abstractmethod
-    def _fetch_my_specific_relation_data(self, relation: Relation, fields: Optional[List[str]]) -> Dict[str, str]:
+    def _fetch_my_specific_relation_data(
+        self, relation: Relation, fields: Optional[List[str]]
+    ) -> Dict[str, str]:
         """Fetch data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         raise NotImplementedError
 
@@ -627,6 +1031,23 @@ class DataRelation(Object, ABC):
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         raise NotImplementedError
+
+    # Optional overrides
+
+    def _legacy_apply_on_fetch(self) -> None:
+        """This function should provide a list of compatibility functions to be applied when fetching (legacy) data."""
+        pass
+
+    def _legacy_apply_on_update(self, fields: List[str]) -> None:
+        """This function should provide a list of compatibility functions to be applied when writing data.
+
+        Since data may be at a legacy version, migration may be mandatory.
+        """
+        pass
+
+    def _legacy_apply_on_delete(self, fields: List[str]) -> None:
+        """This function should provide a list of compatibility functions to be applied when deleting (legacy) data."""
+        pass
 
     # Internal helper methods
 
@@ -645,14 +1066,15 @@ class DataRelation(Object, ABC):
         return field.startswith(PROV_SECRET_PREFIX)
 
     @staticmethod
-    def _generate_secret_label(relation_name: str, relation_id: int, group_mapping: SecretGroup) -> str:
+    def _generate_secret_label(
+        relation_name: str, relation_id: int, group_mapping: SecretGroup
+    ) -> str:
         """Generate unique group_mappings for secrets within a relation context."""
-        return f"{relation_name}.{relation_id}.{group_mapping.value}.secret"
+        return f"{relation_name}.{relation_id}.{group_mapping}.secret"
 
-    @staticmethod
-    def _generate_secret_field_name(group_mapping: SecretGroup) -> str:
+    def _generate_secret_field_name(self, group_mapping: SecretGroup) -> str:
         """Generate unique group_mappings for secrets within a relation context."""
-        return f"{PROV_SECRET_PREFIX}{group_mapping.value}"
+        return f"{PROV_SECRET_PREFIX}{group_mapping}"
 
     def _relation_from_secret_label(self, secret_label: str) -> Optional[Relation]:
         """Retrieve the relation that belongs to a secret label."""
@@ -677,8 +1099,7 @@ class DataRelation(Object, ABC):
         except ModelError:
             return
 
-    @staticmethod
-    def _group_secret_fields(secret_fields: List[str]) -> Dict[SecretGroup, List[str]]:
+    def _group_secret_fields(self, secret_fields: List[str]) -> Dict[SecretGroup, List[str]]:
         """Helper function to arrange secret mappings under their group.
 
         NOTE: All unrecognized items end up in the 'extra' secret bucket.
@@ -686,35 +1107,43 @@ class DataRelation(Object, ABC):
         """
         secret_fieldnames_grouped = {}
         for key in secret_fields:
-            if group := SECRET_LABEL_MAP.get(key):
+            if group := self.secret_label_map.get(key):
                 secret_fieldnames_grouped.setdefault(group, []).append(key)
             else:
-                secret_fieldnames_grouped.setdefault(SecretGroup.EXTRA, []).append(key)
+                secret_fieldnames_grouped.setdefault(SECRET_GROUPS.EXTRA, []).append(key)
         return secret_fieldnames_grouped
 
     def _get_group_secret_contents(
         self,
         relation: Relation,
         group: SecretGroup,
-        secret_fields: Optional[Union[Set[str], List[str]]] = None,
+        secret_fields: Union[Set[str], List[str]] = [],
     ) -> Dict[str, str]:
         """Helper function to retrieve collective, requested contents of a secret."""
-        if not secret_fields:
-            secret_fields = []
-
-        if (secret := self._get_relation_secret(relation.id, group)) and (secret_data := secret.get_content()):
-            return {k: v for k, v in secret_data.items() if k in secret_fields}
+        if (secret := self._get_relation_secret(relation.id, group)) and (
+            secret_data := secret.get_content()
+        ):
+            return {
+                k: v for k, v in secret_data.items() if not secret_fields or k in secret_fields
+            }
         return {}
 
-    @staticmethod
     def _content_for_secret_group(
-        content: Dict[str, str], secret_fields: Set[str], group_mapping: SecretGroup
+        self, content: Dict[str, str], secret_fields: Set[str], group_mapping: SecretGroup
     ) -> Dict[str, str]:
         """Select <field>: <value> pairs from input, that belong to this particular Secret group."""
-        if group_mapping == SecretGroup.EXTRA:
-            return {k: v for k, v in content.items() if k in secret_fields and k not in SECRET_LABEL_MAP.keys()}
+        if group_mapping == SECRET_GROUPS.EXTRA:
+            return {
+                k: v
+                for k, v in content.items()
+                if k in secret_fields and k not in self.secret_label_map.keys()
+            }
 
-        return {k: v for k, v in content.items() if k in secret_fields and SECRET_LABEL_MAP.get(k) == group_mapping}
+        return {
+            k: v
+            for k, v in content.items()
+            if k in secret_fields and self.secret_label_map.get(k) == group_mapping
+        }
 
     @juju_secrets_only
     def _get_relation_secret_data(
@@ -742,11 +1171,11 @@ class DataRelation(Object, ABC):
 
         # If the relation started on a databag, we just stay on the databag
         # (Rolling upgrades may result in a relation starting on databag, getting secrets enabled on-the-fly)
-        # self.local_app is sufficient to check (ignored if Requires, never has secrets -- works if Provides)
+        # self.local_app is sufficient to check (ignored if Requires, never has secrets -- works if Provider)
         fallback_to_databag = (
             req_secret_fields
-            and self.local_unit.is_leader()
-            and set(req_secret_fields) & set(relation.data[self.local_app])
+            and (self.local_unit == self._model.unit and self.local_unit.is_leader())
+            and set(req_secret_fields) & set(relation.data[self.component])
         )
 
         normal_fields = set(impacted_rel_fields)
@@ -769,26 +1198,28 @@ class DataRelation(Object, ABC):
         return (result, normal_fields)
 
     def _fetch_relation_data_without_secrets(
-        self, app: Application, relation: Relation, fields: Optional[List[str]]
+        self, component: Union[Application, Unit], relation: Relation, fields: Optional[List[str]]
     ) -> Dict[str, str]:
         """Fetching databag contents when no secrets are involved.
 
         Since the Provider's databag is the only one holding secrest, we can apply
         a simplified workflow to read the Require's side's databag.
-        This is used typically when the Provides side wants to read the Requires side's data,
+        This is used typically when the Provider side wants to read the Requires side's data,
         or when the Requires side may want to read its own data.
         """
-        if app not in relation.data or not relation.data[app]:
+        if component not in relation.data or not relation.data[component]:
             return {}
 
         if fields:
-            return {k: relation.data[app][k] for k in fields if k in relation.data[app]}
+            return {
+                k: relation.data[component][k] for k in fields if k in relation.data[component]
+            }
         else:
-            return dict(relation.data[app])
+            return dict(relation.data[component])
 
     def _fetch_relation_data_with_secrets(
         self,
-        app: Application,
+        component: Union[Application, Unit],
         req_secret_fields: Optional[List[str]],
         relation: Relation,
         fields: Optional[List[str]] = None,
@@ -797,23 +1228,19 @@ class DataRelation(Object, ABC):
 
         This function has internal logic to resolve if a requested field may be "hidden"
         within a Relation Secret, or directly available as a databag field. Typically
-        used to read the Provides side's databag (eigher by the Requires side, or by
-        Provides side itself).
+        used to read the Provider side's databag (eigher by the Requires side, or by
+        Provider side itself).
         """
         result = {}
         normal_fields = []
 
         if not fields:
-            if app not in relation.data or not relation.data[app]:
+            if component not in relation.data:
                 return {}
 
-            all_fields = list(relation.data[app].keys())
+            all_fields = list(relation.data[component].keys())
             normal_fields = [field for field in all_fields if not self._is_secret_field(field)]
-
-            # There must have been secrets there
-            if all_fields != normal_fields and req_secret_fields:
-                # So we assemble the full fields list (without 'secret-<X>' fields)
-                fields = normal_fields + req_secret_fields
+            fields = normal_fields + req_secret_fields if req_secret_fields else normal_fields
 
         if fields:
             result, normal_fields = self._process_secret_fields(
@@ -821,49 +1248,68 @@ class DataRelation(Object, ABC):
             )
 
         # Processing "normal" fields. May include leftover from what we couldn't retrieve as a secret.
-        # (Typically when Juju3 Requires meets Juju2 Provides)
+        # (Typically when Juju3 Requires meets Juju2 Provider)
         if normal_fields:
-            result.update(self._fetch_relation_data_without_secrets(app, relation, list(normal_fields)))
+            result.update(
+                self._fetch_relation_data_without_secrets(component, relation, list(normal_fields))
+            )
         return result
 
-    def _update_relation_data_without_secrets(self, app: Application, relation: Relation, data: Dict[str, str]) -> None:
+    def _update_relation_data_without_secrets(
+        self, component: Union[Application, Unit], relation: Relation, data: Dict[str, str]
+    ) -> None:
         """Updating databag contents when no secrets are involved."""
-        if app not in relation.data or relation.data[app] is None:
+        if component not in relation.data or relation.data[component] is None:
             return
 
-        if any(self._is_secret_field(key) for key in data.keys()):
-            raise SecretsIllegalUpdateError("Can't update secret {key}.")
-
         if relation:
-            relation.data[app].update(data)
+            relation.data[component].update(data)
 
-    def _delete_relation_data_without_secrets(self, app: Application, relation: Relation, fields: List[str]) -> None:
+    def _delete_relation_data_without_secrets(
+        self, component: Union[Application, Unit], relation: Relation, fields: List[str]
+    ) -> None:
         """Remove databag fields 'fields' from Relation."""
-        if app not in relation.data or not relation.data[app]:
+        if component not in relation.data or relation.data[component] is None:
             return
 
         for field in fields:
             try:
-                relation.data[app].pop(field)
+                relation.data[component].pop(field)
             except KeyError:
                 logger.debug(
-                    "Non-existing field was attempted to be removed from the databag %s, %s",
-                    str(relation.id),
+                    "Non-existing field '%s' was attempted to be removed from the databag (relation ID: %s)",
                     str(field),
+                    str(relation.id),
                 )
                 pass
 
     # Public interface methods
     # Handling Relation Fields seamlessly, regardless if in databag or a Juju Secret
 
+    def as_dict(self, relation_id: int) -> UserDict:
+        """Dict behavior representation of the Abstract Data."""
+        return DataDict(self, relation_id)
+
     def get_relation(self, relation_name, relation_id) -> Relation:
         """Safe way of retrieving a relation."""
-        relation = self.charm.model.get_relation(relation_name, relation_id)
+        relation = self._model.get_relation(relation_name, relation_id)
 
         if not relation:
-            raise DataInterfacesError("Relation %s %s couldn't be retrieved", relation_name, relation_id)
+            raise DataInterfacesError(
+                "Relation %s %s couldn't be retrieved", relation_name, relation_id
+            )
 
         return relation
+
+    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
+        """Get the secret URI for the corresponding group."""
+        secret_field = self._generate_secret_field_name(group)
+        return relation.data[self.component].get(secret_field)
+
+    def set_secret_uri(self, relation: Relation, group: SecretGroup, secret_uri: str) -> None:
+        """Set the secret URI for the corresponding group."""
+        secret_field = self._generate_secret_field_name(group)
+        relation.data[self.component][secret_field] = secret_uri
 
     def fetch_relation_data(
         self,
@@ -881,12 +1327,16 @@ class DataRelation(Object, ABC):
             a dict of the values stored in the relation data bag
                 for all relation instances (indexed by the relation ID).
         """
+        self._legacy_apply_on_fetch()
+
         if not relation_name:
             relation_name = self.relation_name
 
         relations = []
         if relation_ids:
-            relations = [self.get_relation(relation_name, relation_id) for relation_id in relation_ids]
+            relations = [
+                self.get_relation(relation_name, relation_id) for relation_id in relation_ids
+            ]
         else:
             relations = self.relations
 
@@ -896,11 +1346,16 @@ class DataRelation(Object, ABC):
                 data[relation.id] = self._fetch_specific_relation_data(relation, fields)
         return data
 
-    def fetch_relation_field(self, relation_id: int, field: str, relation_name: Optional[str] = None) -> Optional[str]:
+    def fetch_relation_field(
+        self, relation_id: int, field: str, relation_name: Optional[str] = None
+    ) -> Optional[str]:
         """Get a single field from the relation data."""
-        return self.fetch_relation_data([relation_id], [field], relation_name).get(relation_id, {}).get(field)
+        return (
+            self.fetch_relation_data([relation_id], [field], relation_name)
+            .get(relation_id, {})
+            .get(field)
+        )
 
-    @leader_only
     def fetch_my_relation_data(
         self,
         relation_ids: Optional[List[int]] = None,
@@ -912,12 +1367,16 @@ class DataRelation(Object, ABC):
         NOTE: Since only the leader can read the relation's 'this_app'-side
         Application databag, the functionality is limited to leaders
         """
+        self._legacy_apply_on_fetch()
+
         if not relation_name:
             relation_name = self.relation_name
 
         relations = []
         if relation_ids:
-            relations = [self.get_relation(relation_name, relation_id) for relation_id in relation_ids]
+            relations = [
+                self.get_relation(relation_name, relation_id) for relation_id in relation_ids
+            ]
         else:
             relations = self.relations
 
@@ -927,7 +1386,6 @@ class DataRelation(Object, ABC):
                 data[relation.id] = self._fetch_my_specific_relation_data(relation, fields)
         return data
 
-    @leader_only
     def fetch_my_relation_field(
         self, relation_id: int, field: str, relation_name: Optional[str] = None
     ) -> Optional[str]:
@@ -942,6 +1400,8 @@ class DataRelation(Object, ABC):
     @leader_only
     def update_relation_data(self, relation_id: int, data: dict) -> None:
         """Update the data within the relation."""
+        self._legacy_apply_on_update(list(data.keys()))
+
         relation_name = self.relation_name
         relation = self.get_relation(relation_name, relation_id)
         return self._update_relation_data(relation, data)
@@ -949,19 +1409,29 @@ class DataRelation(Object, ABC):
     @leader_only
     def delete_relation_data(self, relation_id: int, fields: List[str]) -> None:
         """Remove field from the relation."""
+        self._legacy_apply_on_delete(fields)
+
         relation_name = self.relation_name
         relation = self.get_relation(relation_name, relation_id)
         return self._delete_relation_data(relation, fields)
 
 
-# Base DataProvides and DataRequires
+class EventHandlers(Object):
+    """Requires-side of the relation."""
 
+    def __init__(self, charm: CharmBase, relation_data: Data, unique_key: str = ""):
+        """Manager of base client relations."""
+        if not unique_key:
+            unique_key = relation_data.relation_name
+        super().__init__(charm, unique_key)
 
-class DataProvides(DataRelation):
-    """Base provides-side of the data products relation."""
+        self.charm = charm
+        self.relation_data = relation_data
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
+        self.framework.observe(
+            charm.on[self.relation_data.relation_name].relation_changed,
+            self._on_relation_changed_event,
+        )
 
     def _diff(self, event: RelationChangedEvent) -> Diff:
         """Retrieves the diff of the data in the relation changed databag.
@@ -973,36 +1443,74 @@ class DataProvides(DataRelation):
             a Diff instance containing the added, deleted and changed
                 keys from the event relation databag.
         """
-        return diff(event, self.local_app)
+        return diff(event, self.relation_data.data_component)
+
+    @abstractmethod
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        raise NotImplementedError
+
+
+# Base ProviderData and RequiresData
+
+
+class ProviderData(Data):
+    """Base provides-side of the data products relation."""
+
+    RESOURCE_FIELD = "database"
+
+    def __init__(
+        self,
+        model: Model,
+        relation_name: str,
+    ) -> None:
+        super().__init__(model, relation_name)
+        self.data_component = self.local_app
 
     # Private methods handling secrets
 
     @juju_secrets_only
-    def _add_relation_secret(self, relation: Relation, content: Dict[str, str], group_mapping: SecretGroup) -> bool:
+    def _add_relation_secret(
+        self,
+        relation: Relation,
+        group_mapping: SecretGroup,
+        secret_fields: Set[str],
+        data: Dict[str, str],
+        uri_to_databag=True,
+    ) -> bool:
         """Add a new Juju Secret that will be registered in the relation databag."""
-        secret_field = self._generate_secret_field_name(group_mapping)
-        if relation.data[self.local_app].get(secret_field):
+        if uri_to_databag and self.get_secret_uri(relation, group_mapping):
             logging.error("Secret for relation %s already exists, not adding again", relation.id)
             return False
+
+        content = self._content_for_secret_group(data, secret_fields, group_mapping)
 
         label = self._generate_secret_label(self.relation_name, relation.id, group_mapping)
         secret = self.secrets.add(label, content, relation)
 
         # According to lint we may not have a Secret ID
-        if secret.meta and secret.meta.id:
-            relation.data[self.local_app][secret_field] = secret.meta.id
+        if uri_to_databag and secret.meta and secret.meta.id:
+            self.set_secret_uri(relation, group_mapping, secret.meta.id)
 
         # Return the content that was added
         return True
 
     @juju_secrets_only
-    def _update_relation_secret(self, relation: Relation, content: Dict[str, str], group_mapping: SecretGroup) -> bool:
+    def _update_relation_secret(
+        self,
+        relation: Relation,
+        group_mapping: SecretGroup,
+        secret_fields: Set[str],
+        data: Dict[str, str],
+    ) -> bool:
         """Update the contents of an existing Juju Secret, referred in the relation databag."""
         secret = self._get_relation_secret(relation.id, group_mapping)
 
         if not secret:
             logging.error("Can't update secret for relation %s", relation.id)
             return False
+
+        content = self._content_for_secret_group(data, secret_fields, group_mapping)
 
         old_content = secret.get_content()
         full_content = copy.deepcopy(old_content)
@@ -1018,13 +1526,13 @@ class DataProvides(DataRelation):
         group: SecretGroup,
         secret_fields: Set[str],
         data: Dict[str, str],
+        uri_to_databag=True,
     ) -> bool:
         """Update contents for Secret group. If the Secret doesn't exist, create it."""
-        secret_content = self._content_for_secret_group(data, secret_fields, group)
         if self._get_relation_secret(relation.id, group):
-            return self._update_relation_secret(relation, secret_content, group)
+            return self._update_relation_secret(relation, group, secret_fields, data)
         else:
-            return self._add_relation_secret(relation, secret_content, group)
+            return self._add_relation_secret(relation, group, secret_fields, data, uri_to_databag)
 
     @juju_secrets_only
     def _delete_relation_secret(
@@ -1043,22 +1551,24 @@ class DataProvides(DataRelation):
             try:
                 new_content.pop(field)
             except KeyError:
-                logging.error(
+                logging.debug(
                     "Non-existing secret was attempted to be removed %s, %s",
                     str(relation.id),
                     str(field),
                 )
                 return False
 
-        secret.set_content(new_content)
-
         # Remove secret from the relation if it's fully gone
         if not new_content:
             field = self._generate_secret_field_name(group)
             try:
-                relation.data[self.local_app].pop(field)
+                relation.data[self.component].pop(field)
             except KeyError:
                 pass
+            label = self._generate_secret_label(self.relation_name, relation.id, group)
+            self.secrets.remove(label)
+        else:
+            secret.set_content(new_content)
 
         # Return the content that was removed
         return True
@@ -1077,25 +1587,28 @@ class DataProvides(DataRelation):
         if secret := self.secrets.get(label):
             return secret
 
-        relation = self.charm.model.get_relation(relation_name, relation_id)
+        relation = self._model.get_relation(relation_name, relation_id)
         if not relation:
             return
 
-        secret_field = self._generate_secret_field_name(group_mapping)
-        if secret_uri := relation.data[self.local_app].get(secret_field):
+        if secret_uri := self.get_secret_uri(relation, group_mapping):
             return self.secrets.get(label, secret_uri)
 
-    def _fetch_specific_relation_data(self, relation: Relation, fields: Optional[List[str]]) -> Dict[str, str]:
-        """Fetching relation data for Provides.
+    def _fetch_specific_relation_data(
+        self, relation: Relation, fields: Optional[List[str]]
+    ) -> Dict[str, str]:
+        """Fetching relation data for Provider.
 
-        NOTE: Since all secret fields are in the Provides side of the databag, we don't need to worry about that
+        NOTE: Since all secret fields are in the Provider side of the databag, we don't need to worry about that
         """
         if not relation.app:
             return {}
 
         return self._fetch_relation_data_without_secrets(relation.app, relation, fields)
 
-    def _fetch_my_specific_relation_data(self, relation: Relation, fields: Optional[List[str]]) -> dict:
+    def _fetch_my_specific_relation_data(
+        self, relation: Relation, fields: Optional[List[str]]
+    ) -> dict:
         """Fetching our own relation data."""
         secret_fields = None
         if relation.app:
@@ -1111,6 +1624,15 @@ class DataProvides(DataRelation):
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
+
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
+
         if relation.app:
             req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
 
@@ -1169,31 +1691,31 @@ class DataProvides(DataRelation):
         """
         self.update_relation_data(relation_id, {"tls-ca": tls_ca})
 
+    # Public functions -- inherited
 
-class DataRequires(DataRelation):
-    """Requires-side of the relation."""
+    fetch_my_relation_data = leader_only(Data.fetch_my_relation_data)
+    fetch_my_relation_field = leader_only(Data.fetch_my_relation_field)
+
+
+class RequirerData(Data):
+    """Requirer-side of the relation."""
 
     SECRET_FIELDS = ["username", "password", "tls", "tls-ca", "uris"]
 
     def __init__(
         self,
-        charm,
+        model,
         relation_name: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of base client relations."""
-        super().__init__(charm, relation_name)
+        super().__init__(model, relation_name)
         self.extra_user_roles = extra_user_roles
         self._secret_fields = list(self.SECRET_FIELDS)
         if additional_secret_fields:
             self._secret_fields += additional_secret_fields
-
-        self.framework.observe(self.charm.on[relation_name].relation_created, self._on_relation_created_event)
-        self.framework.observe(
-            charm.on.secret_changed,
-            self._on_secret_changed_event,
-        )
+        self.data_component = self.local_unit
 
     @property
     def secret_fields(self) -> Optional[List[str]]:
@@ -1201,21 +1723,11 @@ class DataRequires(DataRelation):
         if self.secrets_enabled:
             return self._secret_fields
 
-    def _diff(self, event: RelationChangedEvent) -> Diff:
-        """Retrieves the diff of the data in the relation changed databag.
-
-        Args:
-            event: relation changed event.
-
-        Returns:
-            a Diff instance containing the added, deleted and changed
-                keys from the event relation databag.
-        """
-        return diff(event, self.local_unit)
-
     # Internal helper functions
 
-    def _register_secret_to_relation(self, relation_name: str, relation_id: int, secret_id: str, group: SecretGroup):
+    def _register_secret_to_relation(
+        self, relation_name: str, relation_id: int, secret_id: str, group: SecretGroup
+    ):
         """Fetch secrets and apply local label on them.
 
         [MAGIC HERE]
@@ -1223,13 +1735,13 @@ class DataRequires(DataRelation):
         then <arbitraty_label> will be "stuck" on the Secret object, whenever it may
         appear (i.e. as an event attribute, or fetched manually) on future occasions.
 
-        This will allow us to uniquely identify the secret on Provides side (typically on
+        This will allow us to uniquely identify the secret on Provider side (typically on
         'secret-changed' events), and map it to the corresponding relation.
         """
         label = self._generate_secret_label(relation_name, relation_id, group)
 
-        # Fetchin the Secret's meta information ensuring that it's locally getting registered with
-        CachedSecret(self.charm, label, secret_id).meta
+        # Fetching the Secret's meta information ensuring that it's locally getting registered with
+        CachedSecret(self._model, self.component, label, secret_id).meta
 
     def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
         """Make sure that secrets of the provided list are locally 'registered' from the databag.
@@ -1239,18 +1751,32 @@ class DataRequires(DataRelation):
         if not relation.app:
             return
 
-        for group in SecretGroup:
+        for group in SECRET_GROUPS.groups():
             secret_field = self._generate_secret_field_name(group)
-            if secret_field in params_name_list:
-                if secret_uri := relation.data[relation.app].get(secret_field):
-                    self._register_secret_to_relation(relation.name, relation.id, secret_uri, group)
+            if secret_field in params_name_list and (
+                secret_uri := self.get_secret_uri(relation, group)
+            ):
+                self._register_secret_to_relation(relation.name, relation.id, secret_uri, group)
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
             return False
 
-        data = self.fetch_relation_data([relation.id], ["username", "password"]).get(relation.id, {})
+        data = self.fetch_relation_data([relation.id], ["username", "password"]).get(
+            relation.id, {}
+        )
         return bool(data.get("username")) and bool(data.get("password"))
+
+    # Public functions
+
+    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
+        """Getting relation secret URI for the corresponding Secret Group."""
+        secret_field = self._generate_secret_field_name(group)
+        return relation.data[relation.app].get(secret_field)
+
+    def set_secret_uri(self, relation: Relation, group: SecretGroup, uri: str) -> None:
+        """Setting relation secret URI is not possible for a Requirer."""
+        raise NotImplementedError("Requirer can not change the relation secret URI.")
 
     def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
         """Check if the resource has been created.
@@ -1270,31 +1796,20 @@ class DataRequires(DataRelation):
         """
         if relation_id is not None:
             try:
-                relation = [relation for relation in self.relations if relation.id == relation_id][0]
+                relation = [relation for relation in self.relations if relation.id == relation_id][
+                    0
+                ]
                 return self._is_resource_created_for_relation(relation)
             except IndexError:
                 raise IndexError(f"relation id {relation_id} cannot be accessed")
         else:
             return (
-                all(self._is_resource_created_for_relation(relation) for relation in self.relations)
+                all(
+                    self._is_resource_created_for_relation(relation) for relation in self.relations
+                )
                 if self.relations
                 else False
             )
-
-    # Event handlers
-
-    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
-        """Event emitted when the relation is created."""
-        if not self.local_unit.is_leader():
-            return
-
-        if self.secret_fields:
-            set_encoded_field(event.relation, self.charm.app, REQ_SECRET_FIELDS, self.secret_fields)
-
-    @abstractmethod
-    def _on_secret_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation data has changed."""
-        raise NotImplementedError
 
     # Mandatory internal overrides
 
@@ -1309,11 +1824,15 @@ class DataRequires(DataRelation):
         label = self._generate_secret_label(relation_name, relation_id, group)
         return self.secrets.get(label)
 
-    def _fetch_specific_relation_data(self, relation, fields: Optional[List[str]] = None) -> Dict[str, str]:
-        """Fetching Requires data -- that may include secrets."""
+    def _fetch_specific_relation_data(
+        self, relation, fields: Optional[List[str]] = None
+    ) -> Dict[str, str]:
+        """Fetching Requirer data -- that may include secrets."""
         if not relation.app:
             return {}
-        return self._fetch_relation_data_with_secrets(relation.app, self.secret_fields, relation, fields)
+        return self._fetch_relation_data_with_secrets(
+            relation.app, self.secret_fields, relation, fields
+        )
 
     def _fetch_my_specific_relation_data(self, relation, fields: Optional[List[str]]) -> dict:
         """Fetching our own relation data."""
@@ -1344,8 +1863,687 @@ class DataRequires(DataRelation):
         """
         return self._delete_relation_data_without_secrets(self.local_app, relation, fields)
 
+    # Public functions -- inherited
 
-# General events
+    fetch_my_relation_data = leader_only(Data.fetch_my_relation_data)
+    fetch_my_relation_field = leader_only(Data.fetch_my_relation_field)
+
+
+class RequirerEventHandlers(EventHandlers):
+    """Requires-side of the relation."""
+
+    def __init__(self, charm: CharmBase, relation_data: RequirerData, unique_key: str = ""):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_data, unique_key)
+
+        self.framework.observe(
+            self.charm.on[relation_data.relation_name].relation_created,
+            self._on_relation_created_event,
+        )
+        self.framework.observe(
+            charm.on.secret_changed,
+            self._on_secret_changed_event,
+        )
+
+    # Event handlers
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the relation is created."""
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        if self.relation_data.secret_fields:  # pyright: ignore [reportAttributeAccessIssue]
+            set_encoded_field(
+                event.relation,
+                self.relation_data.component,
+                REQ_SECRET_FIELDS,
+                self.relation_data.secret_fields,  # pyright: ignore [reportAttributeAccessIssue]
+            )
+
+    @abstractmethod
+    def _on_secret_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        raise NotImplementedError
+
+
+################################################################################
+# Peer Relation Data
+################################################################################
+
+
+class DataPeerData(RequirerData, ProviderData):
+    """Represents peer relations data."""
+
+    SECRET_FIELDS = []
+    SECRET_FIELD_NAME = "internal_secret"
+    SECRET_LABEL_MAP = {}
+
+    def __init__(
+        self,
+        model,
+        relation_name: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        additional_secret_group_mapping: Dict[str, str] = {},
+        secret_field_name: Optional[str] = None,
+        deleted_label: Optional[str] = None,
+    ):
+        RequirerData.__init__(
+            self,
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+        )
+        self.secret_field_name = secret_field_name if secret_field_name else self.SECRET_FIELD_NAME
+        self.deleted_label = deleted_label
+        self._secret_label_map = {}
+
+        # Legacy information holders
+        self._legacy_labels = []
+        self._legacy_secret_uri = None
+
+        # Secrets that are being dynamically added within the scope of this event handler run
+        self._new_secrets = []
+        self._additional_secret_group_mapping = additional_secret_group_mapping
+
+        for group, fields in additional_secret_group_mapping.items():
+            if group not in SECRET_GROUPS.groups():
+                setattr(SECRET_GROUPS, group, group)
+            for field in fields:
+                secret_group = SECRET_GROUPS.get_group(group)
+                internal_field = self._field_to_internal_name(field, secret_group)
+                self._secret_label_map.setdefault(group, []).append(internal_field)
+                self._secret_fields.append(internal_field)
+
+    @property
+    def scope(self) -> Optional[Scope]:
+        """Turn component information into Scope."""
+        if isinstance(self.component, Application):
+            return Scope.APP
+        if isinstance(self.component, Unit):
+            return Scope.UNIT
+
+    @property
+    def secret_label_map(self) -> Dict[str, str]:
+        """Property storing secret mappings."""
+        return self._secret_label_map
+
+    @property
+    def static_secret_fields(self) -> List[str]:
+        """Re-definition of the property in a way that dynamically extended list is retrieved."""
+        return self._secret_fields
+
+    @property
+    def secret_fields(self) -> List[str]:
+        """Re-definition of the property in a way that dynamically extended list is retrieved."""
+        return (
+            self.static_secret_fields if self.static_secret_fields else self.current_secret_fields
+        )
+
+    @property
+    def current_secret_fields(self) -> List[str]:
+        """Helper method to get all currently existing secret fields (added statically or dynamically)."""
+        if not self.secrets_enabled:
+            return []
+
+        if len(self._model.relations[self.relation_name]) > 1:
+            raise ValueError(f"More than one peer relation on {self.relation_name}")
+
+        relation = self._model.relations[self.relation_name][0]
+        fields = []
+
+        ignores = [SECRET_GROUPS.get_group("user"), SECRET_GROUPS.get_group("tls")]
+        for group in SECRET_GROUPS.groups():
+            if group in ignores:
+                continue
+            if content := self._get_group_secret_contents(relation, group):
+                fields += list(content.keys())
+        return list(set(fields) | set(self._new_secrets))
+
+    @dynamic_secrets_only
+    def set_secret(
+        self,
+        relation_id: int,
+        field: str,
+        value: str,
+        group_mapping: Optional[SecretGroup] = None,
+    ) -> None:
+        """Public interface method to add a Relation Data field specifically as a Juju Secret.
+
+        Args:
+            relation_id: ID of the relation
+            field: The secret field that is to be added
+            value: The string value of the secret
+            group_mapping: The name of the "secret group", in case the field is to be added to an existing secret
+        """
+        self._legacy_apply_on_update([field])
+
+        full_field = self._field_to_internal_name(field, group_mapping)
+        if self.secrets_enabled and full_field not in self.current_secret_fields:
+            self._new_secrets.append(full_field)
+        if self.valid_field_pattern(field, full_field):
+            self.update_relation_data(relation_id, {full_field: value})
+
+    # Unlike for set_secret(), there's no harm using this operation with static secrets
+    # The restricion is only added to keep the concept clear
+    @dynamic_secrets_only
+    def get_secret(
+        self,
+        relation_id: int,
+        field: str,
+        group_mapping: Optional[SecretGroup] = None,
+    ) -> Optional[str]:
+        """Public interface method to fetch secrets only."""
+        self._legacy_apply_on_fetch()
+
+        full_field = self._field_to_internal_name(field, group_mapping)
+        if (
+            self.secrets_enabled
+            and full_field not in self.current_secret_fields
+            and field not in self.current_secret_fields
+        ):
+            return
+        if self.valid_field_pattern(field, full_field):
+            return self.fetch_my_relation_field(relation_id, full_field)
+
+    @dynamic_secrets_only
+    def delete_secret(
+        self,
+        relation_id: int,
+        field: str,
+        group_mapping: Optional[SecretGroup] = None,
+    ) -> Optional[str]:
+        """Public interface method to delete secrets only."""
+        self._legacy_apply_on_delete([field])
+
+        full_field = self._field_to_internal_name(field, group_mapping)
+        if self.secrets_enabled and full_field not in self.current_secret_fields:
+            logger.warning(f"Secret {field} from group {group_mapping} was not found")
+            return
+
+        if self.valid_field_pattern(field, full_field):
+            self.delete_relation_data(relation_id, [full_field])
+
+    ##########################################################################
+    # Helpers
+    ##########################################################################
+
+    @staticmethod
+    def _field_to_internal_name(field: str, group: Optional[SecretGroup]) -> str:
+        if not group or group == SECRET_GROUPS.EXTRA:
+            return field
+        return f"{field}{GROUP_SEPARATOR}{group}"
+
+    @staticmethod
+    def _internal_name_to_field(name: str) -> Tuple[str, SecretGroup]:
+        parts = name.split(GROUP_SEPARATOR)
+        if not len(parts) > 1:
+            return (parts[0], SECRET_GROUPS.EXTRA)
+        secret_group = SECRET_GROUPS.get_group(parts[1])
+        if not secret_group:
+            raise ValueError(f"Invalid secret field {name}")
+        return (parts[0], secret_group)
+
+    def _group_secret_fields(self, secret_fields: List[str]) -> Dict[SecretGroup, List[str]]:
+        """Helper function to arrange secret mappings under their group.
+
+        NOTE: All unrecognized items end up in the 'extra' secret bucket.
+        Make sure only secret fields are passed!
+        """
+        secret_fieldnames_grouped = {}
+        for key in secret_fields:
+            field, group = self._internal_name_to_field(key)
+            secret_fieldnames_grouped.setdefault(group, []).append(field)
+        return secret_fieldnames_grouped
+
+    def _content_for_secret_group(
+        self, content: Dict[str, str], secret_fields: Set[str], group_mapping: SecretGroup
+    ) -> Dict[str, str]:
+        """Select <field>: <value> pairs from input, that belong to this particular Secret group."""
+        if group_mapping == SECRET_GROUPS.EXTRA:
+            return {k: v for k, v in content.items() if k in self.secret_fields}
+        return {
+            self._internal_name_to_field(k)[0]: v
+            for k, v in content.items()
+            if k in self.secret_fields
+        }
+
+    def valid_field_pattern(self, field: str, full_field: str) -> bool:
+        """Check that no secret group is attempted to be used together without secrets being enabled.
+
+        Secrets groups are impossible to use with versions that are not yet supporting secrets.
+        """
+        if not self.secrets_enabled and full_field != field:
+            logger.error(
+                f"Can't access {full_field}: no secrets available (i.e. no secret groups either)."
+            )
+            return False
+        return True
+
+    ##########################################################################
+    # Backwards compatibility / Upgrades
+    ##########################################################################
+    # These functions are used to keep backwards compatibility on upgrades
+    # Policy:
+    # All data is kept intact until the first write operation. (This allows a minimal
+    # grace period during which rollbacks are fully safe. For more info see spec.)
+    # All data involves:
+    #   - databag
+    #   - secrets content
+    #   - secret labels (!!!)
+    # Legacy functions must return None, and leave an equally consistent state whether
+    # they are executed or skipped (as a high enough versioned execution environment may
+    # not require so)
+
+    # Full legacy stack for each operation
+
+    def _legacy_apply_on_fetch(self) -> None:
+        """All legacy functions to be applied on fetch."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+
+    def _legacy_apply_on_update(self, fields) -> None:
+        """All legacy functions to be applied on update."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+        self._legacy_migration_remove_secret_from_databag(relation, fields)
+        self._legacy_migration_remove_secret_field_name_from_databag(relation)
+
+    def _legacy_apply_on_delete(self, fields) -> None:
+        """All legacy functions to be applied on delete."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+        self._legacy_compat_check_deleted_label(relation, fields)
+
+    # Compatibility
+
+    @legacy_apply_from_version(18)
+    def _legacy_compat_check_deleted_label(self, relation, fields) -> None:
+        """Helper function for legacy behavior.
+
+        As long as https://bugs.launchpad.net/juju/+bug/2028094 wasn't fixed,
+        we did not delete fields but rather kept them in the secret with a string value
+        expressing invalidity. This function is maintainnig that behavior when needed.
+        """
+        if not self.deleted_label:
+            return
+
+        current_data = self.fetch_my_relation_data([relation.id], fields)
+        if current_data is not None:
+            # Check if the secret we wanna delete actually exists
+            # Given the "deleted label", here we can't rely on the default mechanism (i.e. 'key not found')
+            if non_existent := (set(fields) & set(self.secret_fields)) - set(
+                current_data.get(relation.id, [])
+            ):
+                logger.debug(
+                    "Non-existing secret %s was attempted to be removed.",
+                    ", ".join(non_existent),
+                )
+
+    @legacy_apply_from_version(18)
+    def _legacy_compat_secret_uri_from_databag(self, relation) -> None:
+        """Fetching the secret URI from the databag, in case stored there."""
+        self._legacy_secret_uri = relation.data[self.component].get(
+            self._generate_secret_field_name(), None
+        )
+
+    @legacy_apply_from_version(34)
+    def _legacy_compat_generate_prev_labels(self) -> None:
+        """Generator for legacy secret label names, for backwards compatibility.
+
+        Secret label is part of the data that MUST be maintained across rolling upgrades.
+        In case there may be a change on a secret label, the old label must be recognized
+        after upgrades, and left intact until the first write operation -- when we roll over
+        to the new label.
+
+        This function keeps "memory" of previously used secret labels.
+        NOTE: Return value takes decorator into account -- all 'legacy' functions may return `None`
+
+        v0.34 (rev69): Fixing issue https://github.com/canonical/data-platform-libs/issues/155
+                       meant moving from '<app_name>.<scope>' (i.e. 'mysql.app', 'mysql.unit')
+                       to labels '<relation_name>.<app_name>.<scope>' (like 'peer.mysql.app')
+        """
+        if self._legacy_labels:
+            return
+
+        result = []
+        members = [self._model.app.name]
+        if self.scope:
+            members.append(self.scope.value)
+        result.append(f"{'.'.join(members)}")
+        self._legacy_labels = result
+
+    # Migration
+
+    @legacy_apply_from_version(18)
+    def _legacy_migration_remove_secret_from_databag(self, relation, fields: List[str]) -> None:
+        """For Rolling Upgrades -- when moving from databag to secrets usage.
+
+        Practically what happens here is to remove stuff from the databag that is
+        to be stored in secrets.
+        """
+        if not self.secret_fields:
+            return
+
+        secret_fields_passed = set(self.secret_fields) & set(fields)
+        for field in secret_fields_passed:
+            if self._fetch_relation_data_without_secrets(self.component, relation, [field]):
+                self._delete_relation_data_without_secrets(self.component, relation, [field])
+
+    @legacy_apply_from_version(18)
+    def _legacy_migration_remove_secret_field_name_from_databag(self, relation) -> None:
+        """Making sure that the old databag URI is gone.
+
+        This action should not be executed more than once.
+
+        There was a phase (before moving secrets usage to libs) when charms saved the peer
+        secret URI to the databag, and used this URI from then on to retrieve their secret.
+        When upgrading to charm versions using this library, we need to add a label to the
+        secret and access it via label from than on, and remove the old traces from the databag.
+        """
+        # Nothing to do if 'internal-secret' is not in the databag
+        if not (relation.data[self.component].get(self._generate_secret_field_name())):
+            return
+
+        # Making sure that the secret receives its label
+        # (This should have happened by the time we get here, rather an extra security measure.)
+        secret = self._get_relation_secret(relation.id)
+
+        # Either app scope secret with leader executing, or unit scope secret
+        leader_or_unit_scope = self.component != self.local_app or self.local_unit.is_leader()
+        if secret and leader_or_unit_scope:
+            # Databag reference to the secret URI can be removed, now that it's labelled
+            relation.data[self.component].pop(self._generate_secret_field_name(), None)
+
+    ##########################################################################
+    # Event handlers
+    ##########################################################################
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        pass
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the secret has changed."""
+        pass
+
+    ##########################################################################
+    # Overrides of Relation Data handling functions
+    ##########################################################################
+
+    def _generate_secret_label(
+        self, relation_name: str, relation_id: int, group_mapping: SecretGroup
+    ) -> str:
+        members = [relation_name, self._model.app.name]
+        if self.scope:
+            members.append(self.scope.value)
+        if group_mapping != SECRET_GROUPS.EXTRA:
+            members.append(group_mapping)
+        return f"{'.'.join(members)}"
+
+    def _generate_secret_field_name(self, group_mapping: SecretGroup = SECRET_GROUPS.EXTRA) -> str:
+        """Generate unique group_mappings for secrets within a relation context."""
+        return f"{self.secret_field_name}"
+
+    @juju_secrets_only
+    def _get_relation_secret(
+        self,
+        relation_id: int,
+        group_mapping: SecretGroup = SECRET_GROUPS.EXTRA,
+        relation_name: Optional[str] = None,
+    ) -> Optional[CachedSecret]:
+        """Retrieve a Juju Secret specifically for peer relations.
+
+        In case this code may be executed within a rolling upgrade, and we may need to
+        migrate secrets from the databag to labels, we make sure to stick the correct
+        label on the secret, and clean up the local databag.
+        """
+        if not relation_name:
+            relation_name = self.relation_name
+
+        relation = self._model.get_relation(relation_name, relation_id)
+        if not relation:
+            return
+
+        label = self._generate_secret_label(relation_name, relation_id, group_mapping)
+
+        # URI or legacy label is only to applied when moving single legacy secret to a (new) label
+        if group_mapping == SECRET_GROUPS.EXTRA:
+            # Fetching the secret with fallback to URI (in case label is not yet known)
+            # Label would we "stuck" on the secret in case it is found
+            return self.secrets.get(
+                label, self._legacy_secret_uri, legacy_labels=self._legacy_labels
+            )
+        return self.secrets.get(label)
+
+    def _get_group_secret_contents(
+        self,
+        relation: Relation,
+        group: SecretGroup,
+        secret_fields: Union[Set[str], List[str]] = [],
+    ) -> Dict[str, str]:
+        """Helper function to retrieve collective, requested contents of a secret."""
+        secret_fields = [self._internal_name_to_field(k)[0] for k in secret_fields]
+        result = super()._get_group_secret_contents(relation, group, secret_fields)
+        if self.deleted_label:
+            result = {key: result[key] for key in result if result[key] != self.deleted_label}
+        if self._additional_secret_group_mapping:
+            return {self._field_to_internal_name(key, group): result[key] for key in result}
+        return result
+
+    @either_static_or_dynamic_secrets
+    def _fetch_my_specific_relation_data(
+        self, relation: Relation, fields: Optional[List[str]]
+    ) -> Dict[str, str]:
+        """Fetch data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
+        return self._fetch_relation_data_with_secrets(
+            self.component, self.secret_fields, relation, fields
+        )
+
+    @either_static_or_dynamic_secrets
+    def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
+        """Update data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
+        _, normal_fields = self._process_secret_fields(
+            relation,
+            self.secret_fields,
+            list(data),
+            self._add_or_update_relation_secrets,
+            data=data,
+            uri_to_databag=False,
+        )
+
+        normal_content = {k: v for k, v in data.items() if k in normal_fields}
+        self._update_relation_data_without_secrets(self.component, relation, normal_content)
+
+    @either_static_or_dynamic_secrets
+    def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
+        """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
+        if self.secret_fields and self.deleted_label:
+
+            _, normal_fields = self._process_secret_fields(
+                relation,
+                self.secret_fields,
+                fields,
+                self._update_relation_secret,
+                data={field: self.deleted_label for field in fields},
+            )
+        else:
+            _, normal_fields = self._process_secret_fields(
+                relation, self.secret_fields, fields, self._delete_relation_secret, fields=fields
+            )
+        self._delete_relation_data_without_secrets(self.component, relation, list(normal_fields))
+
+    def fetch_relation_data(
+        self,
+        relation_ids: Optional[List[int]] = None,
+        fields: Optional[List[str]] = None,
+        relation_name: Optional[str] = None,
+    ) -> Dict[int, Dict[str, str]]:
+        """This method makes no sense for a Peer Relation."""
+        raise NotImplementedError(
+            "Peer Relation only supports 'self-side' fetch methods: "
+            "fetch_my_relation_data() and fetch_my_relation_field()"
+        )
+
+    def fetch_relation_field(
+        self, relation_id: int, field: str, relation_name: Optional[str] = None
+    ) -> Optional[str]:
+        """This method makes no sense for a Peer Relation."""
+        raise NotImplementedError(
+            "Peer Relation only supports 'self-side' fetch methods: "
+            "fetch_my_relation_data() and fetch_my_relation_field()"
+        )
+
+    ##########################################################################
+    # Public functions -- inherited
+    ##########################################################################
+
+    fetch_my_relation_data = Data.fetch_my_relation_data
+    fetch_my_relation_field = Data.fetch_my_relation_field
+
+
+class DataPeerEventHandlers(RequirerEventHandlers):
+    """Requires-side of the relation."""
+
+    def __init__(self, charm: CharmBase, relation_data: RequirerData, unique_key: str = ""):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_data, unique_key)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        pass
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the secret has changed."""
+        pass
+
+
+class DataPeer(DataPeerData, DataPeerEventHandlers):
+    """Represents peer relations."""
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        additional_secret_group_mapping: Dict[str, str] = {},
+        secret_field_name: Optional[str] = None,
+        deleted_label: Optional[str] = None,
+        unique_key: str = "",
+    ):
+        DataPeerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            additional_secret_group_mapping,
+            secret_field_name,
+            deleted_label,
+        )
+        DataPeerEventHandlers.__init__(self, charm, self, unique_key)
+
+
+class DataPeerUnitData(DataPeerData):
+    """Unit data abstraction representation."""
+
+    SCOPE = Scope.UNIT
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
+    """Unit databag representation."""
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        additional_secret_group_mapping: Dict[str, str] = {},
+        secret_field_name: Optional[str] = None,
+        deleted_label: Optional[str] = None,
+        unique_key: str = "",
+    ):
+        DataPeerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            additional_secret_group_mapping,
+            secret_field_name,
+            deleted_label,
+        )
+        DataPeerEventHandlers.__init__(self, charm, self, unique_key)
+
+
+class DataPeerOtherUnitData(DataPeerUnitData):
+    """Unit data abstraction representation."""
+
+    def __init__(self, unit: Unit, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.local_unit = unit
+        self.component = unit
+
+    def update_relation_data(self, relation_id: int, data: dict) -> None:
+        """This method makes no sense for a Other Peer Relation."""
+        raise NotImplementedError("It's not possible to update data of another unit.")
+
+    def delete_relation_data(self, relation_id: int, fields: List[str]) -> None:
+        """This method makes no sense for a Other Peer Relation."""
+        raise NotImplementedError("It's not possible to delete data of another unit.")
+
+
+class DataPeerOtherUnitEventHandlers(DataPeerEventHandlers):
+    """Requires-side of the relation."""
+
+    def __init__(self, charm: CharmBase, relation_data: DataPeerUnitData):
+        """Manager of base client relations."""
+        unique_key = f"{relation_data.relation_name}-{relation_data.local_unit.name}"
+        super().__init__(charm, relation_data, unique_key=unique_key)
+
+
+class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
+    """Unit databag representation for another unit than the executor."""
+
+    def __init__(
+        self,
+        unit: Unit,
+        charm: CharmBase,
+        relation_name: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        additional_secret_group_mapping: Dict[str, str] = {},
+        secret_field_name: Optional[str] = None,
+        deleted_label: Optional[str] = None,
+    ):
+        DataPeerOtherUnitData.__init__(
+            self,
+            unit,
+            charm.model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            additional_secret_group_mapping,
+            secret_field_name,
+            deleted_label,
+        )
+        DataPeerOtherUnitEventHandlers.__init__(self, charm, self)
+
+
+################################################################################
+# Cross-charm Relatoins Data Handling and Evenets
+################################################################################
+
+# Generic events
 
 
 class ExtraRoleEvent(RelationEvent):
@@ -1360,12 +2558,8 @@ class ExtraRoleEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("extra-user-roles")
 
 
-class AuthenticationEvent(RelationEvent):
-    """Base class for authentication fields for events.
-
-    The amount of logic added here is not ideal -- but this was the only way to preserve
-    the interface when moving to Juju Secrets
-    """
+class RelationEventWithSecret(RelationEvent):
+    """Base class for Relation Events that need to handle secrets."""
 
     @property
     def _secrets(self) -> dict:
@@ -1377,20 +2571,8 @@ class AuthenticationEvent(RelationEvent):
             self._cached_secrets = {}
         return self._cached_secrets
 
-    @property
-    def _jujuversion(self) -> JujuVersion:
-        """Caching jujuversion to avoid a Juju call on each field evaluation.
-
-        DON'T USE the encapsulated helper variable outside of this function
-        """
-        if not hasattr(self, "_cached_jujuversion"):
-            self._cached_jujuversion = None
-        if not self._cached_jujuversion:
-            self._cached_jujuversion = JujuVersion.from_environ()
-        return self._cached_jujuversion
-
     def _get_secret(self, group) -> Optional[Dict[str, str]]:
-        """Retrieveing secrets."""
+        """Retrieving secrets."""
         if not self.app:
             return
         if not self._secrets.get(group):
@@ -1404,7 +2586,15 @@ class AuthenticationEvent(RelationEvent):
     @property
     def secrets_enabled(self):
         """Is this Juju version allowing for Secrets usage?"""
-        return self._jujuversion.has_secrets
+        return JujuVersion.from_environ().has_secrets
+
+
+class AuthenticationEvent(RelationEventWithSecret):
+    """Base class for authentication fields for events.
+
+    The amount of logic added here is not ideal -- but this was the only way to preserve
+    the interface when moving to Juju Secrets
+    """
 
     @property
     def username(self) -> Optional[str]:
@@ -1477,6 +2667,17 @@ class DatabaseProvidesEvent(RelationEvent):
 class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new database is requested for use on this relation."""
 
+    @property
+    def external_node_connectivity(self) -> bool:
+        """Returns the requested external_node_connectivity field."""
+        if not self.relation.app:
+            return False
+
+        return (
+            self.relation.data[self.relation.app].get("external-node-connectivity", "false")
+            == "true"
+        )
+
 
 class DatabaseProvidesEvents(CharmEvents):
     """Database events.
@@ -1487,7 +2688,7 @@ class DatabaseProvidesEvents(CharmEvents):
     database_requested = EventSource(DatabaseRequestedEvent)
 
 
-class DatabaseRequiresEvent(RelationEvent):
+class DatabaseRequiresEvent(RelationEventWithSecret):
     """Base class for database events."""
 
     @property
@@ -1542,6 +2743,11 @@ class DatabaseRequiresEvent(RelationEvent):
         if not self.relation.app:
             return None
 
+        if self.secrets_enabled:
+            secret = self._get_secret("user")
+            if secret:
+                return secret.get("uris")
+
         return self.relation.data[self.relation.app].get("uris")
 
     @property
@@ -1582,26 +2788,11 @@ class DatabaseRequiresEvents(CharmEvents):
 # Database Provider and Requires
 
 
-class DatabaseProvides(DataProvides):
-    """Provider-side of the database relations."""
+class DatabaseProviderData(ProviderData):
+    """Provider-side data of the database relations."""
 
-    on = DatabaseProvidesEvents()  # pyright: ignore [reportGeneralTypeIssues]
-
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
-
-    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation has changed."""
-        # Leader only
-        if not self.local_unit.is_leader():
-            return
-        # Check which data has changed to emit customs events.
-        diff = self._diff(event)
-
-        # Emit a database requested event if the setup key (database name and optional
-        # extra user roles) was added to the relation databag by the application.
-        if "database" in diff.added:
-            getattr(self.on, "database_requested").emit(event.relation, app=event.app, unit=event.unit)
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
 
     def set_database(self, relation_id: int, database_name: str) -> None:
         """Set database name.
@@ -1674,109 +2865,70 @@ class DatabaseProvides(DataProvides):
         """
         self.update_relation_data(relation_id, {"version": version})
 
+    def set_subordinated(self, relation_id: int) -> None:
+        """Raises the subordinated flag in the application relation databag.
 
-class DatabaseRequires(DataRequires):
-    """Requires-side of the database relation."""
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        self.update_relation_data(relation_id, {"subordinated": "true"})
 
-    on = DatabaseRequiresEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+class DatabaseProviderEventHandlers(EventHandlers):
+    """Provider-side of the database relation handlers."""
+
+    on = DatabaseProvidesEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(
+        self, charm: CharmBase, relation_data: DatabaseProviderData, unique_key: str = ""
+    ):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_data, unique_key)
+        # Just to calm down pyright, it can't parse that the same type is being used in the super() call above
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Leader only
+        if not self.relation_data.local_unit.is_leader():
+            return
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit a database requested event if the setup key (database name and optional
+        # extra user roles) was added to the relation databag by the application.
+        if "database" in diff.added:
+            getattr(self.on, "database_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+
+class DatabaseProvides(DatabaseProviderData, DatabaseProviderEventHandlers):
+    """Provider-side of the database relations."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        DatabaseProviderData.__init__(self, charm.model, relation_name)
+        DatabaseProviderEventHandlers.__init__(self, charm, self)
+
+
+class DatabaseRequirerData(RequirerData):
+    """Requirer-side of the database relation."""
 
     def __init__(
         self,
-        charm,
+        model: Model,
         relation_name: str,
         database_name: str,
         extra_user_roles: Optional[str] = None,
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        external_node_connectivity: bool = False,
     ):
         """Manager of database client relations."""
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.database = database_name
         self.relations_aliases = relations_aliases
-
-        # Define custom event names for each alias.
-        if relations_aliases:
-            # Ensure the number of aliases does not exceed the maximum
-            # of connections allowed in the specific relation.
-            relation_connection_limit = self.charm.meta.requires[relation_name].limit
-            if len(relations_aliases) != relation_connection_limit:
-                raise ValueError(
-                    f"The number of aliases must match the maximum number of connections allowed in the relation. "
-                    f"Expected {relation_connection_limit}, got {len(relations_aliases)}"
-                )
-
-            for relation_alias in relations_aliases:
-                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
-                self.on.define_event(f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent)
-                self.on.define_event(
-                    f"{relation_alias}_read_only_endpoints_changed",
-                    DatabaseReadOnlyEndpointsChangedEvent,
-                )
-
-    def _on_secret_changed_event(self, event: SecretChangedEvent):
-        """Event notifying about a new value of a secret."""
-        pass
-
-    def _assign_relation_alias(self, relation_id: int) -> None:
-        """Assigns an alias to a relation.
-
-        This function writes in the unit data bag.
-
-        Args:
-            relation_id: the identifier for a particular relation.
-        """
-        # If no aliases were provided, return immediately.
-        if not self.relations_aliases:
-            return
-
-        # Return if an alias was already assigned to this relation
-        # (like when there are more than one unit joining the relation).
-        relation = self.charm.model.get_relation(self.relation_name, relation_id)
-        if relation and relation.data[self.local_unit].get("alias"):
-            return
-
-        # Retrieve the available aliases (the ones that weren't assigned to any relation).
-        available_aliases = self.relations_aliases[:]
-        for relation in self.charm.model.relations[self.relation_name]:
-            alias = relation.data[self.local_unit].get("alias")
-            if alias:
-                logger.debug("Alias %s was already assigned to relation %d", alias, relation.id)
-                available_aliases.remove(alias)
-
-        # Set the alias in the unit relation databag of the specific relation.
-        relation = self.charm.model.get_relation(self.relation_name, relation_id)
-        if relation:
-            relation.data[self.local_unit].update({"alias": available_aliases[0]})
-
-        # We need to set relation alias also on the application level so,
-        # it will be accessible in show-unit juju command, executed for a consumer application unit
-        if self.local_unit.is_leader():
-            self.update_relation_data(relation_id, {"alias": available_aliases[0]})
-
-    def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
-        """Emit an aliased event to a particular relation if it has an alias.
-
-        Args:
-            event: the relation changed event that was received.
-            event_name: the name of the event to emit.
-        """
-        alias = self._get_relation_alias(event.relation.id)
-        if alias:
-            getattr(self.on, f"{alias}_{event_name}").emit(event.relation, app=event.app, unit=event.unit)
-
-    def _get_relation_alias(self, relation_id: int) -> Optional[str]:
-        """Returns the relation alias.
-
-        Args:
-            relation_id: the identifier for a particular relation.
-
-        Returns:
-            the relation alias or None if the relation was not found.
-        """
-        for relation in self.charm.model.relations[self.relation_name]:
-            if relation.id == relation_id:
-                return relation.data[self.local_unit].get("alias")
-        return None
+        self.external_node_connectivity = external_node_connectivity
 
     def is_postgresql_plugin_enabled(self, plugin: str, relation_index: int = 0) -> bool:
         """Returns whether a plugin is enabled in the database.
@@ -1805,19 +2957,132 @@ class DatabaseRequires(DataRequires):
 
         host = host.split(":")[0]
 
-        content = self.fetch_relation_data([relation_id], ["username", "password"]).get(relation_id, {})
+        content = self.fetch_relation_data([relation_id], ["username", "password"]).get(
+            relation_id, {}
+        )
         user = content.get("username")
         password = content.get("password")
 
-        connection_string = f"host='{host}' dbname='{self.database}' user='{user}' password='{password}'"
+        connection_string = (
+            f"host='{host}' dbname='{self.database}' user='{user}' password='{password}'"
+        )
         try:
             with psycopg.connect(connection_string) as connection:
                 with connection.cursor() as cursor:
-                    cursor.execute("SELECT TRUE FROM pg_extension WHERE extname=%s::text;", (plugin,))
+                    cursor.execute(
+                        "SELECT TRUE FROM pg_extension WHERE extname=%s::text;", (plugin,)
+                    )
                     return cursor.fetchone() is not None
         except psycopg.Error as e:
-            logger.exception(f"failed to check whether {plugin} plugin is enabled in the database: %s", str(e))
+            logger.exception(
+                f"failed to check whether {plugin} plugin is enabled in the database: %s", str(e)
+            )
             return False
+
+
+class DatabaseRequirerEventHandlers(RequirerEventHandlers):
+    """Requires-side of the relation."""
+
+    on = DatabaseRequiresEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(
+        self, charm: CharmBase, relation_data: DatabaseRequirerData, unique_key: str = ""
+    ):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_data, unique_key)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+        # Define custom event names for each alias.
+        if self.relation_data.relations_aliases:
+            # Ensure the number of aliases does not exceed the maximum
+            # of connections allowed in the specific relation.
+            relation_connection_limit = self.charm.meta.requires[
+                self.relation_data.relation_name
+            ].limit
+            if len(self.relation_data.relations_aliases) != relation_connection_limit:
+                raise ValueError(
+                    f"The number of aliases must match the maximum number of connections allowed in the relation. "
+                    f"Expected {relation_connection_limit}, got {len(self.relation_data.relations_aliases)}"
+                )
+
+        if self.relation_data.relations_aliases:
+            for relation_alias in self.relation_data.relations_aliases:
+                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
+                self.on.define_event(
+                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
+                )
+                self.on.define_event(
+                    f"{relation_alias}_read_only_endpoints_changed",
+                    DatabaseReadOnlyEndpointsChangedEvent,
+                )
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+    def _assign_relation_alias(self, relation_id: int) -> None:
+        """Assigns an alias to a relation.
+
+        This function writes in the unit data bag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        # If no aliases were provided, return immediately.
+        if not self.relation_data.relations_aliases:
+            return
+
+        # Return if an alias was already assigned to this relation
+        # (like when there are more than one unit joining the relation).
+        relation = self.charm.model.get_relation(self.relation_data.relation_name, relation_id)
+        if relation and relation.data[self.relation_data.local_unit].get("alias"):
+            return
+
+        # Retrieve the available aliases (the ones that weren't assigned to any relation).
+        available_aliases = self.relation_data.relations_aliases[:]
+        for relation in self.charm.model.relations[self.relation_data.relation_name]:
+            alias = relation.data[self.relation_data.local_unit].get("alias")
+            if alias:
+                logger.debug("Alias %s was already assigned to relation %d", alias, relation.id)
+                available_aliases.remove(alias)
+
+        # Set the alias in the unit relation databag of the specific relation.
+        relation = self.charm.model.get_relation(self.relation_data.relation_name, relation_id)
+        if relation:
+            relation.data[self.relation_data.local_unit].update({"alias": available_aliases[0]})
+
+        # We need to set relation alias also on the application level so,
+        # it will be accessible in show-unit juju command, executed for a consumer application unit
+        if self.relation_data.local_unit.is_leader():
+            self.relation_data.update_relation_data(relation_id, {"alias": available_aliases[0]})
+
+    def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
+        """Emit an aliased event to a particular relation if it has an alias.
+
+        Args:
+            event: the relation changed event that was received.
+            event_name: the name of the event to emit.
+        """
+        alias = self._get_relation_alias(event.relation.id)
+        if alias:
+            getattr(self.on, f"{alias}_{event_name}").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _get_relation_alias(self, relation_id: int) -> Optional[str]:
+        """Returns the relation alias.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+
+        Returns:
+            the relation alias or None if the relation was not found.
+        """
+        for relation in self.charm.model.relations[self.relation_data.relation_name]:
+            if relation.id == relation_id:
+                return relation.data[self.relation_data.local_unit].get("alias")
+        return None
 
     def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
         """Event emitted when the database relation is created."""
@@ -1828,36 +3093,55 @@ class DatabaseRequires(DataRequires):
 
         # Sets both database and extra user roles in the relation
         # if the roles are provided. Otherwise, sets only the database.
-        if not self.local_unit.is_leader():
+        if not self.relation_data.local_unit.is_leader():
             return
 
-        if self.extra_user_roles:
-            self.update_relation_data(
-                event.relation.id,
-                {
-                    "database": self.database,
-                    "extra-user-roles": self.extra_user_roles,
-                },
-            )
-        else:
-            self.update_relation_data(event.relation.id, {"database": self.database})
+        event_data = {"database": self.relation_data.database}
+
+        if self.relation_data.extra_user_roles:
+            event_data["extra-user-roles"] = self.relation_data.extra_user_roles
+
+        # set external-node-connectivity field
+        if self.relation_data.external_node_connectivity:
+            event_data["external-node-connectivity"] = "true"
+
+        self.relation_data.update_relation_data(event.relation.id, event_data)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""
+        is_subordinate = False
+        remote_unit_data = None
+        for key in event.relation.data.keys():
+            if isinstance(key, Unit) and not key.name.startswith(self.charm.app.name):
+                remote_unit_data = event.relation.data[key]
+            elif isinstance(key, Application) and key.name != self.charm.app.name:
+                is_subordinate = event.relation.data[key].get("subordinated") == "true"
+
+        if is_subordinate:
+            if not remote_unit_data:
+                return
+
+            if remote_unit_data.get("state") != "ready":
+                return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
         # Register all new secrets with their labels
-        if any(newval for newval in diff.added if self._is_secret_field(newval)):
-            self._register_secrets_to_relation(event.relation, diff.added)
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
         # Check if the database is created
         # (the database charm shared the credentials).
-        secret_field_user = self._generate_secret_field_name(SecretGroup.USER)
-        if ("username" in diff.added and "password" in diff.added) or secret_field_user in diff.added:
+        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
+        if (
+            "username" in diff.added and "password" in diff.added
+        ) or secret_field_user in diff.added:
             # Emit the default event (the one without an alias).
             logger.info("database created at %s", datetime.now())
-            getattr(self.on, "database_created").emit(event.relation, app=event.app, unit=event.unit)
+            getattr(self.on, "database_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
 
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "database_created")
@@ -1871,7 +3155,9 @@ class DatabaseRequires(DataRequires):
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
-            getattr(self.on, "endpoints_changed").emit(event.relation, app=event.app, unit=event.unit)
+            getattr(self.on, "endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
 
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "endpoints_changed")
@@ -1885,13 +3171,45 @@ class DatabaseRequires(DataRequires):
         if "read-only-endpoints" in diff.added or "read-only-endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("read-only-endpoints changed on %s", datetime.now())
-            getattr(self.on, "read_only_endpoints_changed").emit(event.relation, app=event.app, unit=event.unit)
+            getattr(self.on, "read_only_endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
 
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "read_only_endpoints_changed")
 
 
-# Kafka related events
+class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
+    """Provider-side of the database relations."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        database_name: str,
+        extra_user_roles: Optional[str] = None,
+        relations_aliases: Optional[List[str]] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        external_node_connectivity: bool = False,
+    ):
+        DatabaseRequirerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            database_name,
+            extra_user_roles,
+            relations_aliases,
+            additional_secret_fields,
+            external_node_connectivity,
+        )
+        DatabaseRequirerEventHandlers.__init__(self, charm, self)
+
+
+################################################################################
+# Charm-specific Relations Data and Events
+################################################################################
+
+# Kafka Events
 
 
 class KafkaProvidesEvent(RelationEvent):
@@ -1984,27 +3302,13 @@ class KafkaRequiresEvents(CharmEvents):
 # Kafka Provides and Requires
 
 
-class KafkaProvides(DataProvides):
+class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
-    on = KafkaProvidesEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    RESOURCE_FIELD = "topic"
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
-
-    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation has changed."""
-        # Leader only
-        if not self.local_unit.is_leader():
-            return
-
-        # Check which data has changed to emit customs events.
-        diff = self._diff(event)
-
-        # Emit a topic requested event if the setup key (topic name and optional
-        # extra user roles) was added to the relation databag by the application.
-        if "topic" in diff.added:
-            getattr(self.on, "topic_requested").emit(event.relation, app=event.app, unit=event.unit)
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
 
     def set_topic(self, relation_id: int, topic: str) -> None:
         """Set topic name in the application relation databag.
@@ -2043,14 +3347,47 @@ class KafkaProvides(DataProvides):
         self.update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
 
-class KafkaRequires(DataRequires):
-    """Requires-side of the Kafka relation."""
+class KafkaProviderEventHandlers(EventHandlers):
+    """Provider-side of the Kafka relation."""
 
-    on = KafkaRequiresEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KafkaProviderData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Leader only
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit a topic requested event if the setup key (topic name and optional
+        # extra user roles) was added to the relation databag by the application.
+        if "topic" in diff.added:
+            getattr(self.on, "topic_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+
+class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
+    """Provider-side of the Kafka relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        KafkaProviderData.__init__(self, charm.model, relation_name)
+        KafkaProviderEventHandlers.__init__(self, charm, self)
+
+
+class KafkaRequirerData(RequirerData):
+    """Requirer-side of the Kafka relation."""
 
     def __init__(
         self,
-        charm,
+        model: Model,
         relation_name: str,
         topic: str,
         extra_user_roles: Optional[str] = None,
@@ -2058,9 +3395,7 @@ class KafkaRequires(DataRequires):
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of Kafka client relations."""
-        # super().__init__(charm, relation_name)
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
-        self.charm = charm
+        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
 
@@ -2076,19 +3411,34 @@ class KafkaRequires(DataRequires):
             raise ValueError(f"Error on topic '{value}', cannot be a wildcard.")
         self._topic = value
 
+
+class KafkaRequirerEventHandlers(RequirerEventHandlers):
+    """Requires-side of the Kafka relation."""
+
+    on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KafkaRequirerData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
     def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
         """Event emitted when the Kafka relation is created."""
         super()._on_relation_created_event(event)
 
-        if not self.local_unit.is_leader():
+        if not self.relation_data.local_unit.is_leader():
             return
 
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
-        relation_data = {
-            f: getattr(self, f.replace("-", "_"), "") for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
-        }
+        relation_data = {"topic": self.relation_data.topic}
 
-        self.update_relation_data(event.relation.id, relation_data)
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+
+        if self.relation_data.consumer_group_prefix:
+            relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
+
+        self.relation_data.update_relation_data(event.relation.id, relation_data)
 
     def _on_secret_changed_event(self, event: SecretChangedEvent):
         """Event notifying about a new value of a secret."""
@@ -2103,11 +3453,13 @@ class KafkaRequires(DataRequires):
         # (the Kafka charm shared the credentials).
 
         # Register all new secrets with their labels
-        if any(newval for newval in diff.added if self._is_secret_field(newval)):
-            self._register_secrets_to_relation(event.relation, diff.added)
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
-        secret_field_user = self._generate_secret_field_name(SecretGroup.USER)
-        if ("username" in diff.added and "password" in diff.added) or secret_field_user in diff.added:
+        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
+        if (
+            "username" in diff.added and "password" in diff.added
+        ) or secret_field_user in diff.added:
             # Emit the default event (the one without an alias).
             logger.info("topic created at %s", datetime.now())
             getattr(self.on, "topic_created").emit(event.relation, app=event.app, unit=event.unit)
@@ -2125,6 +3477,30 @@ class KafkaRequires(DataRequires):
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
             return
+
+
+class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
+    """Provider-side of the Kafka relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        topic: str,
+        extra_user_roles: Optional[str] = None,
+        consumer_group_prefix: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+    ) -> None:
+        KafkaRequirerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            topic,
+            extra_user_roles,
+            consumer_group_prefix,
+            additional_secret_fields,
+        )
+        KafkaRequirerEventHandlers.__init__(self, charm, self)
 
 
 # Opensearch related events
@@ -2177,26 +3553,13 @@ class OpenSearchRequiresEvents(CharmEvents):
 # OpenSearch Provides and Requires Objects
 
 
-class OpenSearchProvides(DataProvides):
+class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
 
-    on = OpenSearchProvidesEvents()  # pyright: ignore[reportGeneralTypeIssues]
+    RESOURCE_FIELD = "index"
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
-
-    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation has changed."""
-        # Leader only
-        if not self.local_unit.is_leader():
-            return
-        # Check which data has changed to emit customs events.
-        diff = self._diff(event)
-
-        # Emit an index requested event if the setup key (index name and optional extra user roles)
-        # have been added to the relation databag by the application.
-        if "index" in diff.added:
-            getattr(self.on, "index_requested").emit(event.relation, app=event.app, unit=event.unit)
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
 
     def set_index(self, relation_id: int, index: str) -> None:
         """Set the index in the application relation databag.
@@ -2228,47 +3591,91 @@ class OpenSearchProvides(DataProvides):
         self.update_relation_data(relation_id, {"version": version})
 
 
-class OpenSearchRequires(DataRequires):
-    """Requires-side of the OpenSearch relation."""
+class OpenSearchProvidesEventHandlers(EventHandlers):
+    """Provider-side of the OpenSearch relation."""
 
-    on = OpenSearchRequiresEvents()  # pyright: ignore[reportGeneralTypeIssues]
+    on = OpenSearchProvidesEvents()  # pyright: ignore[reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: OpenSearchProvidesData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Leader only
+        if not self.relation_data.local_unit.is_leader():
+            return
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit an index requested event if the setup key (index name and optional extra user roles)
+        # have been added to the relation databag by the application.
+        if "index" in diff.added:
+            getattr(self.on, "index_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+
+class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers):
+    """Provider-side of the OpenSearch relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        OpenSearchProvidesData.__init__(self, charm.model, relation_name)
+        OpenSearchProvidesEventHandlers.__init__(self, charm, self)
+
+
+class OpenSearchRequiresData(RequirerData):
+    """Requires data side of the OpenSearch relation."""
 
     def __init__(
         self,
-        charm,
+        model: Model,
         relation_name: str,
         index: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of OpenSearch client relations."""
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
-        self.charm = charm
+        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.index = index
+
+
+class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
+    """Requires events side of the OpenSearch relation."""
+
+    on = OpenSearchRequiresEvents()  # pyright: ignore[reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: OpenSearchRequiresData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
 
     def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
         """Event emitted when the OpenSearch relation is created."""
         super()._on_relation_created_event(event)
 
-        if not self.local_unit.is_leader():
+        if not self.relation_data.local_unit.is_leader():
             return
 
         # Sets both index and extra user roles in the relation if the roles are provided.
         # Otherwise, sets only the index.
-        data = {"index": self.index}
-        if self.extra_user_roles:
-            data["extra-user-roles"] = self.extra_user_roles
+        data = {"index": self.relation_data.index}
+        if self.relation_data.extra_user_roles:
+            data["extra-user-roles"] = self.relation_data.extra_user_roles
 
-        self.update_relation_data(event.relation.id, data)
+        self.relation_data.update_relation_data(event.relation.id, data)
 
     def _on_secret_changed_event(self, event: SecretChangedEvent):
         """Event notifying about a new value of a secret."""
         if not event.secret.label:
             return
 
-        relation = self._relation_from_secret_label(event.secret.label)
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
         if not relation:
-            logging.info(f"Received secret {event.secret.label} but couldn't parse, seems irrelevant")
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
             return
 
         if relation.app == self.charm.app:
@@ -2280,7 +3687,9 @@ class OpenSearchRequires(DataRequires):
                 remote_unit = unit
 
         logger.info("authentication updated")
-        getattr(self.on, "authentication_updated").emit(relation, app=relation.app, unit=remote_unit)
+        getattr(self.on, "authentication_updated").emit(
+            relation, app=relation.app, unit=remote_unit
+        )
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the OpenSearch relation has changed.
@@ -2291,19 +3700,23 @@ class OpenSearchRequires(DataRequires):
         diff = self._diff(event)
 
         # Register all new secrets with their labels
-        if any(newval for newval in diff.added if self._is_secret_field(newval)):
-            self._register_secrets_to_relation(event.relation, diff.added)
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
-        secret_field_user = self._generate_secret_field_name(SecretGroup.USER)
-        secret_field_tls = self._generate_secret_field_name(SecretGroup.TLS)
+        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
+        secret_field_tls = self.relation_data._generate_secret_field_name(SECRET_GROUPS.TLS)
         updates = {"username", "password", "tls", "tls-ca", secret_field_user, secret_field_tls}
         if len(set(diff._asdict().keys()) - updates) < len(diff):
             logger.info("authentication updated at: %s", datetime.now())
-            getattr(self.on, "authentication_updated").emit(event.relation, app=event.app, unit=event.unit)
+            getattr(self.on, "authentication_updated").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
 
         # Check if the index is created
         # (the OpenSearch charm shares the credentials).
-        if ("username" in diff.added and "password" in diff.added) or secret_field_user in diff.added:
+        if (
+            "username" in diff.added and "password" in diff.added
+        ) or secret_field_user in diff.added:
             # Emit the default event (the one without an alias).
             logger.info("index created at: %s", datetime.now())
             getattr(self.on, "index_created").emit(event.relation, app=event.app, unit=event.unit)
@@ -2321,3 +3734,25 @@ class OpenSearchRequires(DataRequires):
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
             return
+
+
+class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers):
+    """Requires-side of the OpenSearch relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        index: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+    ) -> None:
+        OpenSearchRequiresData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            index,
+            extra_user_roles,
+            additional_secret_fields,
+        )
+        OpenSearchRequiresEventHandlers.__init__(self, charm, self)

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,7 @@ from ops.charm import (
     RelationDepartedEvent,
     RelationEvent,
 )
-from ops.main import main
+from ops import main
 from ops.model import (
     ActiveStatus,
     BlockedStatus,


### PR DESCRIPTION
# Description

When testing the machine charm I found a few things that needed to be updated:
- The bundle was installing Livepatch from `ops1.x/edge`. The charm is now available from `ops1.x/stable` so the bundle has been updated.
- The machine constraints on the bundle were quite low so those have been bumped up.
- There was a deprecation warning when running Juju actions (see below) updated the charm for this.
```
/var/lib/juju/agents/unit-livepatch-0/charm/./src/charm.py:530: DeprecationWarning: Calling `ops.main.main()` is deprecated, call `ops.main()` instead
  main(OperatorMachineCharm)
```
Additionally, I updated the postgres charm library.