### PR TITLE
Improve multi-unit function

### DIFF
--- a/src/actions/schema_upgrade.py
+++ b/src/actions/schema_upgrade.py
@@ -43,9 +43,4 @@ def on_schema_upgrade_action(self: OperatorMachineCharm, event: ActionEvent) -> 
                 }
             )
 
-            # We can just send a None event to the method, because `event` here
-            # is an action event, and they're not deferrable by definition, and
-            # they raise a runtime exception. We don't want to end up passing
-            # such an event to the `_config_changed` method (where we normally
-            # use `event.defer`).
-            self._config_changed(None)
+            self._restart_all_units()

--- a/src/charm.py
+++ b/src/charm.py
@@ -175,7 +175,10 @@ class OperatorMachineCharm(CharmBase):
 
         This method is meant to be used by action hooks that *do not* update the
         state. It's because upon updating the state, the non-leader units will
-        get receive the cue via the peer-relation-changed event.
+        receive the cue via the peer-relation-changed event.
+
+        This method is meant to be called by the leader unit, otherwise, it does
+        nothing.
         """
         if not self.unit.is_leader() or not self._state.is_ready():
             return
@@ -189,11 +192,16 @@ class OperatorMachineCharm(CharmBase):
 
         This method is meant to be used by action hooks that *do not* update the
         state. It's because upon updating the state, the non-leader units will
-        get receive the cue via the peer-relation-changed event.
+        receive the cue via the peer-relation-changed event.
+
+        This method is meant to be called by the leader unit, otherwise, it does
+        nothing.
         """
         if not self.unit.is_leader() or not self._state.is_ready():
             return
         self._restart_non_leader_units()
+
+        # Restart the leader unit (current unit).
         self._update_workload_configuration(None)
 
     def _config_changed(self, event: ConfigChangedEvent):
@@ -237,10 +245,10 @@ class OperatorMachineCharm(CharmBase):
         """
         Update snap internal configuration, additionally validating the DB is ready each time.
 
-        Note that given event should be deferrable. For example, action events
-        (of type ActionEvent), will raise exception if their `defer` method is
-        invoked. So, the caller of this method should pass event as None if it's
-        not a deferrable event.
+        Note that the given event should be deferrable. For example, action
+        events (of type ActionEvent), will raise exception if their `defer`
+        method is invoked. So, the caller of this method should pass event as
+        None if it's not a deferrable event.
         """
         can_continue = (
             self._check_required_config_assigned() and self._check_install_and_relations() and self._database_migrated()

--- a/src/charm.py
+++ b/src/charm.py
@@ -183,7 +183,9 @@ class OperatorMachineCharm(CharmBase):
         if not self.unit.is_leader() or not self._state.is_ready():
             return
         # By incrementing a value in the state, an peer-relation-changed event
-        # will be fired and the non-leader units will respond to it.
+        # will be fired and the non-leader units will respond to it. Note that
+        # Python int type is unbounded, so no overflow exception will occur
+        # (e.g., when there is a crash loop happening).
         self._state.restart_cue = 1 + (self._state.restart_cue or 0)
 
     def _restart_all_units(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -266,19 +266,16 @@ class OperatorMachineCharm(CharmBase):
         except SnapError as e:
             logging.error("error occurred when attempting to restart snap: %s", e)
             self.set_status_and_log("Livepatch failed to restart.", MaintenanceStatus)
-            if event is not None:
-                event.defer()
+            self._defer(event)
             return
 
         if self.unit.status.message == AWAIT_POSTGRES_RELATION:
-            if event is not None:
-                event.defer()
+            self._defer(event)
             return
 
         if self.livepatch_running is not True:
             self.set_status_and_log("Livepatch failed to restart.", MaintenanceStatus)
-            if event is not None:
-                event.defer()
+            self._defer(event)
             return
 
         self._update_unit_status()
@@ -554,6 +551,17 @@ class OperatorMachineCharm(CharmBase):
         """Log and set unit status simultaneously."""
         logging.info(msg)
         self.unit.status = status(msg)
+
+    def _defer(self, event: Optional[HookEvent]):
+        """
+        Defer given event object if it's not None.
+
+        This is a helper method to avoid repeating none checks. It should only
+        be used when the event object can be None.
+        """
+        if not event:
+            return
+        event.defer()
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,7 +253,7 @@ class OperatorMachineCharm(CharmBase):
             prefixed_configuration = {f"lp.{key}": val for key, val in configuration.items()}
             self.get_livepatch_snap.set(prefixed_configuration)
         except SnapError as e:
-            # This *shouldn"t* fire, but would rather be safe!
+            # This *shouldn't* fire, but would rather be safe!
             logging.error(
                 "error occurred when attempting to set snap configuration value %s",
                 e,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,7 +29,8 @@ logger = logging.getLogger(__name__)
 class TestDeployment:
     """Integration tests for charm."""
 
-    async def assert_http(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    async def assert_http(
         self, ops_test: OpsTest, protocol: str, application: str, unit: int, port: int, path: str = ""
     ) -> str:
         """


### PR DESCRIPTION
This PR improves the charm regarding multi-unit deployments.

Previously, running the `schema-upgrade` action would result in an inconsistent status among the leader and non-leaders. This PR adds a helper field to the `_state` object so that by changing it in the leader unit, all non-leader ones receive the event and refresh their workload.

Fixes CSS-11463