### PR TITLE
Add integration with CVE service charm

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -5,6 +5,9 @@ header:
       content: |
         Copyright [year] [owner]
         See LICENSE file for licensing details.
+      pattern: |
+        Copyright \d{4} Canonical Ltd.
+        See LICENSE file for licensing details.
     paths:
       - '**'
     paths-ignore:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Livepatch can be optionally integrated with [`pro-airgapped-server`](https://cha
 juju integrate canonical-livepatch-server:pro-airgapped-server pro-airgapped-server
 ```
 
+### Livepatch CVE service (optional, requires)
+
+Livepatch can be optionally integrated with [Livepatch CVE service](https://charmhub.io/canonical-livepatch-cve-k8s) via the `cve-catalog` endpoint. This integration provides the Livepatch server with the information about CVEs fixed in Ubuntu kernels.
+
+Since there is no machine charm for the Livepatch CVE service, to integrate with
+it, an cross-model/cross-controller relation has to be made:
+
+```sh
+# On the Livepatch CVE service model:
+juju offer canonical-livepatch-cve-k8s:cve-catlaog cve-catalog
+# On the Livepatch server model:
+juju consume <CONTROLLER>:<CVE SERVICE MODEL>.cve-catalog
+juju integrate canonical-livepatch-server cve-catalog
+```
+
 ## Documentation
 
 For more detailed instructions on deploying Livepatch server, please see the documentation for this service, available on the [Livepatch website](https://ubuntu.com/security/livepatch/docs).

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,22 +5,10 @@
 # https://juju.is/docs/sdk/charmcraft-config
 type: "charm"
 
-# Note that ops 2.0 requires Python 3.8+ which is only shipped on Ubuntu 20.04 and above.
-bases:
-  - build-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures:
-          - amd64
-    run-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures:
-          - amd64
-      - name: "ubuntu"
-        channel: "22.04"
-        architectures:
-          - amd64
+base: ubuntu@24.04
+platforms:
+  amd64:
+
 parts:
   charm:
     charm-strict-dependencies: true

--- a/config.yaml
+++ b/config.yaml
@@ -292,6 +292,48 @@ options:
     default: 5m
     description: How often to check for new blocklist entries.
     type: string
+
+  cve-lookup.enabled:
+    default: false
+    description: |
+      Whether or not if this instance of Livepatch Server should lookup fixed CVEs in response to client requests.
+    type: boolean
+  cve-lookup.auth-required:
+    default: false
+    description: |
+      Whether or not requests to retrieve fixed CVEs should be authenticated.
+    type: boolean
+  cve-sync.enabled:
+    default: false
+    description: |
+      Whether or not if this instance of Livepatch Server should sync fixed CVEs data.
+    type: boolean
+  cve-sync.source-url:
+    default: ""
+    description: |
+      Address of Livepatch CVE service to sync fixed CVEs data from.
+    type: string
+  cve-sync.interval:
+    default: "1h"
+    description: Period between automatic refreshing of fixed CVE data.
+    type: string
+  cve-sync.proxy.enabled:
+    default: false
+    description: Whether or not to proxy fixed CVE data syncs.
+    type: boolean
+  cve-sync.proxy.http:
+    default: ""
+    description: A comma separated list HTTP proxies to query fixed CVE data.
+    type: string
+  cve-sync.proxy.https:
+    default: ""
+    description: A comma separated list HTTPS proxies to query fixed CVE data.
+    type: string
+  cve-sync.proxy.no-proxy:
+    default: ""
+    description: A comma separated list of domains, IP CIDRs and/or ports to block when querying fixed CVE data.
+    type: string
+
   machine-reports.database.enabled:
     default: false
     description: Whether or not to enabled machine reports writes to PostgreSQL.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,6 +34,10 @@ requires:
   database:
     interface: postgresql_client
     limit: 1 # Most charms only handle a single PostgreSQL Application.
+  cve-catalog:
+    interface: cve-catalog
+    limit: 1
+    optional: true
   pro-airgapped-server:
     interface: livepatch-pro-airgapped-server
     limit: 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,6 +56,7 @@ DATABASE_NAME = "livepatch"
 DATABASE_RELATION = "database"
 DATABASE_RELATION_LEGACY = "database-legacy"
 PRO_AIRGAPPED_SERVER_RELATION = "pro-airgapped-server"
+CVE_CATALOG_RELATION = "cve-catalog"
 TRUSTED_CA_FILENAME = "/usr/local/share/ca-certificates/trusted-contracts.ca.crt"
 
 
@@ -122,6 +123,10 @@ class OperatorMachineCharm(CharmBase):
         self.framework.observe(
             self.on.pro_airgapped_server_relation_departed, self._on_pro_airgapped_server_relation_departed
         )
+
+        # Livepatch CVE service
+        self.framework.observe(self.on.cve_catalog_relation_changed, self._on_cve_catalog_relation_changed)
+        self.framework.observe(self.on.cve_catalog_relation_broken, self._on_cve_catalog_relation_broken)
 
         # Actions
         self.framework.observe(self.on.enable_action, self.on_enable_action)
@@ -284,6 +289,12 @@ class OperatorMachineCharm(CharmBase):
                 configuration["contracts.url"] = address
                 configuration.pop("contracts.user", None)
                 configuration.pop("contracts.password", None)
+
+        cve_service_address = self._get_available_cve_service()
+        if cve_service_address and self.unit.is_leader():
+            # Note that other env vars are already set from the configuration.
+            configuration["cve-sync.enabled"] = True
+            configuration["cve-sync.source-url"] = cve_service_address
 
         try:
             prefixed_configuration = {f"lp.{key}": val for key, val in configuration.items()}
@@ -525,6 +536,23 @@ class OperatorMachineCharm(CharmBase):
         port = data.get("port")
         netloc = hostname + (f":{port}" if port else "")
         return urlunparse(ParseResult(scheme, netloc, "", "", "", ""))
+
+    def _on_cve_catalog_relation_changed(self, event: RelationChangedEvent):
+        """Handle cve-catalog relation-changed event."""
+        self._update_workload_configuration(event)
+
+    def _on_cve_catalog_relation_broken(self, event: RelationDepartedEvent):
+        """Handle cve-catalog relation-broken event."""
+        self._update_workload_configuration(event)
+
+    def _get_available_cve_service(self) -> Optional[str]:
+        """Return the Livepatch CVE service address, if any, taken from related app/unit."""
+        relation = self.model.get_relation(CVE_CATALOG_RELATION)
+        if not relation:
+            return None
+
+        address = relation.data.get(relation.app).get("url", "")
+        return address if address else None
 
     ###########
     # ACTIONS #

--- a/src/constants/snap.py
+++ b/src/constants/snap.py
@@ -4,6 +4,6 @@
 """Snap names and commands constants."""
 
 SERVER_SNAP_NAME = "canonical-livepatch-server"
-SERVER_SNAP_REVISION = 46
+SERVER_SNAP_REVISION = 47
 SCHEMA_UPGRADE_COMMAND = "schema-tool"
 SCHEMA_VERSION_CHECK = "check-schema-version"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -485,6 +485,60 @@ class TestCharm(unittest.TestCase):
         self.harness.remove_relation(pro_rel_id)
         self.assertTrue(self.snap_mock.set.called)
 
+    def test_cve_catalog_relation__success(self):
+        """Test cve-catalog relation."""
+        self.start_leader_unit()
+
+        expected_config = {
+            "lp.cve-lookup.enabled": False,  # Should not get enabled automatically.
+            "lp.cve-sync.enabled": True,
+            "lp.cve-sync.source-url": "scheme://some.host.name:9999",
+            "lp.cve-sync.interval": "1h",  # Default config value.
+        }
+
+        def snap_set_mock(prefixed_configuration: Dict[str, Any]):
+            self.assertEqual(prefixed_configuration, prefixed_configuration | expected_config)
+
+        self.snap_mock.set = Mock(side_effect=snap_set_mock)
+        cves_rel_id = self.harness.add_relation("cve-catalog", "livepatch-cve-service")
+        self.harness.add_relation_unit(cves_rel_id, "livepatch-cve-service/0")
+        self.harness.update_relation_data(
+            cves_rel_id,
+            "livepatch-cve-service",
+            {
+                "url": "scheme://some.host.name:9999",
+            },
+        )
+
+        self.assertTrue(self.snap_mock.set.called)
+
+    def test_cve_catalog_relation__relation_removed(self):
+        """Test when cve-catalog is removed."""
+        self.start_leader_unit()
+
+        cves_rel_id = self.harness.add_relation("cve-catalog", "livepatch-cve-service")
+        self.harness.add_relation_unit(cves_rel_id, "livepatch-cve-service/0")
+        self.harness.update_relation_data(
+            cves_rel_id,
+            "livepatch-cve-service",
+            {
+                "url": "scheme://some.host.name:9999",
+            },
+        )
+
+        expected_config = {
+            "lp.cve-lookup.enabled": False,
+            "lp.cve-sync.enabled": False,
+        }
+
+        def snap_set_mock(prefixed_configuration: Dict[str, Any]):
+            self.assertEqual(prefixed_configuration, prefixed_configuration | expected_config)
+
+        self.snap_mock.set = Mock(side_effect=snap_set_mock)
+        # Now we remove the relation.
+        self.harness.remove_relation(cves_rel_id)
+        self.assertTrue(self.snap_mock.set.called)
+
     def test_install(self):
         """test install event handler."""
         self.snap_mock.present = False


### PR DESCRIPTION
This PR adds integration with the CVE service charm.

The PR should not be merged until we have released the server snap that supports the corresponding functionalities.

Fixes CSS-12873